### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete string escaping or encoding

### DIFF
--- a/src/git/git-manager.js
+++ b/src/git/git-manager.js
@@ -68,7 +68,9 @@ export class GitManager {
     if (!this.hasUncommittedChanges()) return null;
     // Stage everything before commit
     this._run('add -A');
-    const escaped = message.replace(/"/g, '\\"');
+    const escaped = message
+      .replace(/\\/g, '\\\\')  // escape backslashes
+      .replace(/"/g, '\\"');   // then escape double quotes
     this._run(`commit -m "${escaped}"`);
     const sha = this._run('rev-parse --short HEAD');
     eventBus.emit('git.committed', { message, sha, branch: this.getCurrentBranch() });


### PR DESCRIPTION
Potential fix for [https://github.com/sinsonido/agentforge/security/code-scanning/2](https://github.com/sinsonido/agentforge/security/code-scanning/2)

In general, the safest way to fix this is to avoid building shell commands with manually escaped strings. Instead, either (a) pass arguments as an array to a child-process API that does not invoke a shell, or (b) correctly escape all characters that are significant to the target interpreter (here, the shell), including backslashes. Since we cannot change code outside the shown snippet (e.g. the implementation of `_run`), the least disruptive change is to ensure that the commit message is properly escaped for double quotes *and* backslashes in the current quoting scheme.

The current pattern is: `this._run(`commit -m "${escaped}"`);` with `escaped = message.replace(/"/g, '\\"');`. To correctly represent a string inside double quotes in a shell command, every backslash must be escaped first, then every double quote must be escaped. A standard fix is:

```js
const escaped = message
  .replace(/\\/g, '\\\\')  // escape backslashes
  .replace(/"/g, '\\"');   // then escape double quotes
```

This keeps existing functionality (a simple commit with `-m`), but removes the incomplete escaping problem that CodeQL highlights. No new imports or external libraries are needed; this is pure string manipulation in the same file. The only changes are on line 71 in `src/git/git-manager.js`, possibly expanding it to multiple lines.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
