### PR TITLE
chore(ui): Tailwind v4 theme bridge, QuotaStatus type, sort deps

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -9,31 +9,32 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "react-router-dom": "^7.0.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "recharts": "^2.15.0",
-    "lucide-react": "^0.475.0",
-    "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
-    "tailwind-merge": "^3.0.2",
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-progress": "^1.1.2",
     "@radix-ui/react-scroll-area": "^1.2.3",
     "@radix-ui/react-separator": "^1.1.2",
     "@radix-ui/react-slot": "^1.2.0",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.475.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.0.0",
+    "recharts": "^2.15.0",
+    "tailwind-merge": "^3.0.2",
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@tailwindcss/vite": "^4.0.0",
+    "@types/node": "^25.3.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.4",
-    "typescript": "~5.7.2",
-    "vite": "^6.1.0",
     "tailwindcss": "^4.0.0",
-    "@tailwindcss/vite": "^4.0.0"
+    "typescript": "~5.7.2",
+    "vite": "^6.1.0"
   }
 }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,5 +1,31 @@
 @import "tailwindcss";
 
+@theme inline {
+  --color-background: hsl(var(--background));
+  --color-foreground: hsl(var(--foreground));
+  --color-card: hsl(var(--card));
+  --color-card-foreground: hsl(var(--card-foreground));
+  --color-popover: hsl(var(--popover));
+  --color-popover-foreground: hsl(var(--popover-foreground));
+  --color-primary: hsl(var(--primary));
+  --color-primary-foreground: hsl(var(--primary-foreground));
+  --color-secondary: hsl(var(--secondary));
+  --color-secondary-foreground: hsl(var(--secondary-foreground));
+  --color-muted: hsl(var(--muted));
+  --color-muted-foreground: hsl(var(--muted-foreground));
+  --color-accent: hsl(var(--accent));
+  --color-accent-foreground: hsl(var(--accent-foreground));
+  --color-destructive: hsl(var(--destructive));
+  --color-destructive-foreground: hsl(var(--destructive-foreground));
+  --color-border: hsl(var(--border));
+  --color-input: hsl(var(--input));
+  --color-ring: hsl(var(--ring));
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+}
+
 @layer base {
   :root {
     --background: 0 0% 100%;
@@ -23,12 +49,11 @@
     --ring: 240 5.9% 10%;
     --radius: 0.5rem;
   }
-}
 
-@layer base {
   * {
     border-color: hsl(var(--border));
   }
+
   body {
     background-color: hsl(var(--background));
     color: hsl(var(--foreground));

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -13,7 +13,7 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 }
 
 export const api = {
-  status: () => request<{ ok: boolean; orchestrator: { running: boolean }; tasks: Record<string, number>; quotas: Record<string, unknown>; agents: Record<string, unknown> }>('/status'),
+  status: () => request<{ ok: boolean; orchestrator: { running: boolean }; tasks: Record<string, number>; quotas: Record<string, import('../types/api').QuotaStatus>; agents: Record<string, unknown> }>('/status'),
   tasks: (status?: string) => request<{ ok: boolean; tasks: import('../types/api').Task[] }>(`/tasks${status ? `?status=${status}` : ''}`),
   createTask: (body: { title: string; type?: string; priority?: string; agent_id?: string }) =>
     request<{ ok: boolean; task: import('../types/api').Task }>('/tasks', { method: 'POST', body: JSON.stringify(body) }),


### PR DESCRIPTION
## Summary

- Sort `package.json` dependencies/devDependencies alphabetically
- Add `@types/node ^25.3.0` to devDependencies
- Add `@theme inline` block to `index.css` to properly map shadcn CSS variables to Tailwind v4 color tokens
- Merge duplicate `@layer base` blocks into one
- Strengthen `api.status()` quotas type from `unknown` to `QuotaStatus`

## Test plan
- [ ] `npm run ui:dev` builds without TypeScript errors
- [ ] shadcn components render with correct colors (theme bridge active)
- [ ] `api.status()` returns correctly typed `quotas` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)