### PR TITLE
test(e2e): agents view E2E tests

### DIFF
--- a/e2e/tests/agents.spec.ts
+++ b/e2e/tests/agents.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test'
+
+// Agents defined in e2e/fixtures/agentforge.test.yml
+const TEST_AGENTS = ['Architect', 'Developer', 'Tester']
+
+test.describe('Agents — list and edit', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/agents')
+  })
+
+  test('shows all configured agents', async ({ page }) => {
+    for (const name of TEST_AGENTS) {
+      await expect(page.getByText(name, { exact: true })).toBeVisible()
+    }
+  })
+
+  test('each agent card shows its state badge', async ({ page }) => {
+    const badges = page.getByText('idle')
+    await expect(badges.first()).toBeVisible()
+  })
+
+  test('settings button opens edit dialog for an agent', async ({ page }) => {
+    // Click the settings icon on the first agent card (Architect)
+    await page.getByText('Architect').locator('..').locator('..').getByRole('button').click()
+
+    await expect(page.getByRole('dialog')).toBeVisible()
+    await expect(page.getByText('Edit Agent: architect')).toBeVisible()
+    await expect(page.getByPlaceholder('Leave blank to keep current').first()).toBeVisible()
+  })
+
+  test('Cancel closes edit dialog without saving', async ({ page }) => {
+    await page.getByText('Architect').locator('..').locator('..').getByRole('button').click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Cancel' }).click()
+    await expect(page.getByRole('dialog')).not.toBeVisible()
+  })
+
+  test('can update agent model override', async ({ page }) => {
+    await page.getByText('Developer').locator('..').locator('..').getByRole('button').click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+
+    await page.getByPlaceholder('Leave blank to keep current').first().fill('claude-haiku-4')
+    await page.getByRole('button', { name: 'Save' }).click()
+
+    // Dialog closes on success
+    await expect(page.getByRole('dialog')).not.toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary
Adds 5 E2E tests for the Agents view against the real backend with test DB.

## Tests added (`e2e/tests/agents.spec.ts`)
- All 3 configured agents (Architect, Developer, Tester) are listed
- Agent cards show `idle` state badge
- Settings button opens edit dialog with correct agent ID
- Cancel closes dialog without saving
- Model override field can be saved (dialog closes on success)

## Test plan
- [x] 5/5 tests pass locally (3.9s)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)