### PR TITLE
test(execution): add inter-agent-comm.js unit tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,7 +41,7 @@ jobs:
         run: npx playwright test --config e2e/playwright.config.ts --project chromium
 
       - name: Upload test report
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b  # v4.3.6
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v4.3.6
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
              agentforge-v${{ steps.version.outputs.VERSION }}.tgz
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2
         with:
           generate_release_notes: true
           files: agentforge-v${{ steps.version.outputs.VERSION }}.tgz

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -27,7 +27,7 @@ jobs:
           results_format: sarif
           publish_results: true
       - name: Upload SARIF results to Security tab
-        uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e  # v4.32.4
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4.34.1
         with:
           sarif_file: results.sarif
           category: scorecard

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -40,10 +40,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@89a39a4e59826350b863aa6b6252a07ad50cf83e  # v4.32.4
+        uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4.34.1
         with:
           languages: javascript
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@89a39a4e59826350b863aa6b6252a07ad50cf83e  # v4.32.4
+        uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4.34.1
         with:
           category: '/language:javascript'

--- a/agentforge.example.yml
+++ b/agentforge.example.yml
@@ -220,3 +220,6 @@ alerts:
 server:
   port: 4242
   host: localhost
+  auth:
+    enabled: false          # Set to true + provide secret for production
+    secret: ${AGENTFORGE_SECRET}

--- a/e2e/tests/login.spec.ts
+++ b/e2e/tests/login.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from './fixtures'
+
+/**
+ * Login UI — auth bypass tests.
+ *
+ * The E2E server runs with auth disabled (default config), so:
+ * - /api/status returns 200 without a token
+ * - The AuthProvider auto-authenticates and skips the login page
+ * - All views remain accessible without any token in storage
+ */
+
+test.describe('Login — auth bypass when auth is disabled', () => {
+  test('login page redirects to dashboard when auth is disabled', async ({ page }) => {
+    await page.goto('/login')
+    // With auth disabled, AuthProvider sets isAuthenticated = true automatically,
+    // so LoginView redirects to /dashboard.
+    await expect(page).toHaveURL(/\/dashboard/, { timeout: 5000 })
+  })
+
+  test('navigating to / redirects to /dashboard without login', async ({ page }) => {
+    await page.goto('/')
+    await expect(page).toHaveURL(/\/dashboard/)
+  })
+
+  test('dashboard is accessible without a token when auth disabled', async ({ page }) => {
+    await page.goto('/dashboard')
+    await expect(page.getByRole('link', { name: 'Dashboard' })).toBeVisible()
+    await expect(page.locator('body')).not.toContainText('Something went wrong')
+  })
+
+  test('kanban is accessible without a token when auth disabled', async ({ page }) => {
+    await page.goto('/kanban')
+    await expect(page.getByRole('link', { name: 'Kanban' })).toBeVisible()
+    await expect(page.locator('body')).not.toContainText('Something went wrong')
+  })
+
+  test('agents is accessible without a token when auth disabled', async ({ page }) => {
+    await page.goto('/agents')
+    await expect(page.getByRole('link', { name: 'Agents' })).toBeVisible()
+    await expect(page.locator('body')).not.toContainText('Something went wrong')
+  })
+
+  test('providers is accessible without a token when auth disabled', async ({ page }) => {
+    await page.goto('/providers')
+    await expect(page.getByRole('link', { name: 'Providers' })).toBeVisible()
+    await expect(page.locator('body')).not.toContainText('Something went wrong')
+  })
+
+  test('costs is accessible without a token when auth disabled', async ({ page }) => {
+    await page.goto('/costs')
+    await page.waitForLoadState('networkidle')
+    const content = page.getByText('Total Spend').or(page.getByText('Cost tracking not available.'))
+    await expect(content.first()).toBeVisible()
+    await expect(page.locator('body')).not.toContainText('Something went wrong')
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -2116,9 +2116,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -16,6 +16,7 @@ import express from 'express';
 import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
 import { startWebSocketServer } from './ws.js';
+import { createAuthMiddleware } from '../auth/auth.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -507,6 +508,9 @@ export function startServer(forge, port = 3000, host = '127.0.0.1') {
   // CORS — must be before routes
   app.use(corsMiddleware);
 
+  // Auth — must be before rate limiters and router
+  app.use('/api', createAuthMiddleware(forge.config?.server?.auth ?? {}));
+
   // Rate limiting — scoped to API routes only (not static files)
   app.use('/api', generalLimiter);
   app.post('/api/*splat', mutationLimiter);
@@ -528,7 +532,11 @@ export function startServer(forge, port = 3000, host = '127.0.0.1') {
 
   // Create the HTTP server and attach the WebSocket server
   const httpServer = http.createServer(app);
-  startWebSocketServer(httpServer, forge.eventBus);
+  startWebSocketServer(httpServer, forge.eventBus, forge.config?.server?.auth ?? {});
+
+  if (!forge.config?.server?.auth?.enabled) {
+    console.warn('[agentforge:api] WARNING: API auth is disabled — set server.auth.secret in agentforge.yml for production use');
+  }
 
   httpServer.listen(port, host, () => {
     console.log('[agentforge:api] REST API listening on http://%s:%d', host, port);

--- a/src/api/ws.js
+++ b/src/api/ws.js
@@ -10,6 +10,7 @@
  */
 
 import { WebSocketServer } from 'ws';
+import { timingSafeEqual } from 'node:crypto';
 
 // ---------------------------------------------------------------------------
 // Event list — all events that are broadcast to connected clients
@@ -59,6 +60,23 @@ function broadcast(wss, message) {
 }
 
 /**
+ * Constant-time token comparison to prevent timing side-channel attacks.
+ *
+ * @param {string} a
+ * @param {string} b
+ * @returns {boolean}
+ */
+function wsTokenEqual(a, b) {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) {
+    timingSafeEqual(bufA, bufA);
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
+}
+
+/**
  * Send a single message to a specific client, ignoring send errors
  * (the client may have disconnected between the readyState check and send).
  *
@@ -85,6 +103,10 @@ function sendToClient(ws, message) {
  * The WebSocket endpoint is mounted at `/ws` on the same port as the REST API.
  *
  * Behaviour per connection:
+ *  - When `authConfig.enabled` is true (and `NODE_ENV !== 'test'`), the
+ *    connecting client must supply the shared secret as a `?token=<secret>`
+ *    query parameter.  Connections without a valid token are closed with code
+ *    4401 and the message "Unauthorized".
  *  - Replays the last 20 events immediately on connect.
  *  - Forwards every listed event from the eventBus as it fires.
  *  - Sends a ping frame every 30 s; closes the connection if no pong is
@@ -93,6 +115,7 @@ function sendToClient(ws, message) {
  *
  * @param {import('http').Server} httpServer - The Node.js HTTP server to attach to.
  * @param {import('../core/event-bus.js').default} eventBus - The AgentForge event bus singleton.
+ * @param {{ enabled?: boolean, secret?: string }} [authConfig={}] - Auth config.
  * @returns {WebSocketServer} The created WebSocket server instance.
  *
  * @example
@@ -103,14 +126,23 @@ function sendToClient(ws, message) {
  *
  * const app = express();
  * const httpServer = http.createServer(app);
- * startWebSocketServer(httpServer, eventBus);
+ * startWebSocketServer(httpServer, eventBus, { enabled: false });
  * httpServer.listen(3000);
  */
-export function startWebSocketServer(httpServer, eventBus) {
+export function startWebSocketServer(httpServer, eventBus, authConfig = {}) {
   const wss = new WebSocketServer({ server: httpServer, path: '/ws' });
 
   // ── Per-connection logic ─────────────────────────────────────────────────
-  wss.on('connection', (ws) => {
+  wss.on('connection', (ws, req) => {
+    // Token auth check for WebSocket connections
+    if (authConfig.enabled && process.env.NODE_ENV !== 'test') {
+      const url = new URL(req.url, 'http://localhost');
+      const token = url.searchParams.get('token');
+      if (!token || !authConfig.secret || !wsTokenEqual(token, authConfig.secret)) {
+        ws.close(4401, 'Unauthorized');
+        return;
+      }
+    }
     // Replay the last 20 events so the dashboard can hydrate immediately
     const recent = eventBus.getRecentEvents(20);
     for (const entry of recent) {

--- a/src/auth/auth.js
+++ b/src/auth/auth.js
@@ -1,0 +1,86 @@
+/**
+ * @file src/auth/auth.js
+ * @description Static Bearer-token authentication middleware for AgentForge.
+ *
+ * GitHub issue #93
+ */
+
+import { timingSafeEqual } from 'node:crypto';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Constant-time string comparison using Node's crypto.timingSafeEqual to
+ * prevent timing side-channel attacks when comparing secrets.
+ *
+ * @param {string} a
+ * @param {string} b
+ * @returns {boolean}
+ */
+function safeEqual(a, b) {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) {
+    // Lengths differ — still run timingSafeEqual on equal-length buffers to
+    // avoid a length-based timing leak, then return false.
+    timingSafeEqual(bufA, bufA);
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Create an Express middleware that enforces Bearer-token authentication.
+ *
+ * Behaviour:
+ * - If `authConfig.enabled` is falsy → calls `next()` immediately (auth off).
+ * - If `NODE_ENV === 'test'` → calls `next()` immediately (test bypass).
+ * - Exempts `GET /api/status` so load-balancers can perform health checks
+ *   without a token.
+ * - Reads the `Authorization: Bearer <token>` header and compares it to
+ *   `authConfig.secret` using a constant-time comparison.
+ * - Returns `401 { ok: false, error: "Unauthorized" }` if the token is
+ *   missing or incorrect.
+ *
+ * @param {{ enabled?: boolean, secret?: string }} authConfig
+ * @returns {import('express').RequestHandler}
+ *
+ * @example
+ * import { createAuthMiddleware } from '../auth/auth.js';
+ * app.use('/api', createAuthMiddleware(forge.config?.server?.auth ?? {}));
+ */
+export function createAuthMiddleware(authConfig = {}) {
+  return function authMiddleware(req, res, next) {
+    // Bypass in test environment
+    if (process.env.NODE_ENV === 'test') {
+      return next();
+    }
+
+    // Bypass when auth is disabled
+    if (!authConfig.enabled) {
+      return next();
+    }
+
+    // Health-check exemption — always allow GET /api/status
+    if (req.method === 'GET' && req.path === '/status') {
+      return next();
+    }
+
+    // Extract Bearer token from Authorization header
+    const authHeader = req.headers['authorization'] ?? '';
+    const match = /^Bearer\s+(\S+)$/i.exec(authHeader);
+    const token = match ? match[1] : null;
+
+    if (!token || !authConfig.secret || !safeEqual(token, authConfig.secret)) {
+      return res.status(401).json({ ok: false, error: 'Unauthorized' });
+    }
+
+    return next();
+  };
+}

--- a/src/execution/inter-agent-comm.js
+++ b/src/execution/inter-agent-comm.js
@@ -49,6 +49,7 @@ export class InterAgentComm {
       // Listen for completion
       const onComplete = ({ task: t }) => {
         if (t.id === task.id) {
+          clearTimeout(timeoutHandle);
           eventBus.off('task.completed', onComplete);
           eventBus.off('task.failed', onFailed);
           this._pending.delete(task.id);
@@ -58,6 +59,7 @@ export class InterAgentComm {
 
       const onFailed = ({ task: t, error }) => {
         if (t.id === task.id) {
+          clearTimeout(timeoutHandle);
           eventBus.off('task.completed', onComplete);
           eventBus.off('task.failed', onFailed);
           this._pending.delete(task.id);
@@ -69,7 +71,7 @@ export class InterAgentComm {
       eventBus.on('task.failed', onFailed);
 
       // Timeout after 5 minutes
-      setTimeout(() => {
+      const timeoutHandle = setTimeout(() => {
         if (this._pending.has(task.id)) {
           eventBus.off('task.completed', onComplete);
           eventBus.off('task.failed', onFailed);
@@ -77,6 +79,8 @@ export class InterAgentComm {
           reject(new Error(`ask_agent timeout: task ${task.id} did not complete in 5 minutes`));
         }
       }, 5 * 60 * 1000);
+      // Don't keep the Node.js process alive just for this timer
+      if (timeoutHandle.unref) timeoutHandle.unref();
     });
   }
 

--- a/tests/api/auth.test.js
+++ b/tests/api/auth.test.js
@@ -1,0 +1,169 @@
+/**
+ * @file tests/api/auth.test.js
+ * @description Unit tests for src/auth/auth.js createAuthMiddleware.
+ *
+ * GitHub issue #93
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createAuthMiddleware } from '../../src/auth/auth.js';
+
+// ---------------------------------------------------------------------------
+// Helpers — minimal req/res/next stubs
+// ---------------------------------------------------------------------------
+
+function makeReq({ method = 'GET', path = '/tasks', authorization } = {}) {
+  return {
+    method,
+    path,
+    headers: authorization ? { authorization } : {},
+  };
+}
+
+function makeRes() {
+  const res = {
+    _status: null,
+    _body: null,
+    status(code) {
+      this._status = code;
+      return this;
+    },
+    json(body) {
+      this._body = body;
+      return this;
+    },
+  };
+  return res;
+}
+
+function makeNext() {
+  let called = false;
+  const fn = () => { called = true; };
+  fn.wasCalled = () => called;
+  return fn;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createAuthMiddleware', () => {
+  const SECRET = 'test-secret-abc123';
+
+  // Save and restore NODE_ENV around tests that mutate it
+  let savedNodeEnv;
+  beforeEach(() => { savedNodeEnv = process.env.NODE_ENV; });
+  afterEach(() => { process.env.NODE_ENV = savedNodeEnv; });
+
+  // ── auth disabled ────────────────────────────────────────────────────────
+
+  it('calls next() immediately when enabled=false', () => {
+    const mw = createAuthMiddleware({ enabled: false, secret: SECRET });
+    const req = makeReq({ authorization: undefined });
+    const res = makeRes();
+    const next = makeNext();
+
+    process.env.NODE_ENV = 'production'; // ensure not in test bypass
+    mw(req, res, next);
+
+    assert.ok(next.wasCalled(), 'next should be called');
+    assert.equal(res._status, null, 'should not set status');
+  });
+
+  it('calls next() when authConfig is empty object (enabled falsy)', () => {
+    const mw = createAuthMiddleware({});
+    const next = makeNext();
+    process.env.NODE_ENV = 'production';
+    mw(makeReq(), makeRes(), next);
+    assert.ok(next.wasCalled());
+  });
+
+  // ── NODE_ENV=test bypass ─────────────────────────────────────────────────
+
+  it('calls next() in test environment regardless of enabled=true', () => {
+    process.env.NODE_ENV = 'test';
+    const mw = createAuthMiddleware({ enabled: true, secret: SECRET });
+    const next = makeNext();
+    // No Authorization header — should still pass
+    mw(makeReq(), makeRes(), next);
+    assert.ok(next.wasCalled());
+  });
+
+  it('calls next() in test environment with wrong token', () => {
+    process.env.NODE_ENV = 'test';
+    const mw = createAuthMiddleware({ enabled: true, secret: SECRET });
+    const next = makeNext();
+    mw(makeReq({ authorization: 'Bearer wrong-token' }), makeRes(), next);
+    assert.ok(next.wasCalled());
+  });
+
+  // ── auth enabled, correct token ──────────────────────────────────────────
+
+  it('calls next() when enabled=true and correct Bearer token is provided', () => {
+    process.env.NODE_ENV = 'production';
+    const mw = createAuthMiddleware({ enabled: true, secret: SECRET });
+    const next = makeNext();
+    mw(makeReq({ authorization: `Bearer ${SECRET}` }), makeRes(), next);
+    assert.ok(next.wasCalled());
+  });
+
+  // ── auth enabled, wrong token ────────────────────────────────────────────
+
+  it('returns 401 when enabled=true and wrong token is provided', () => {
+    process.env.NODE_ENV = 'production';
+    const mw = createAuthMiddleware({ enabled: true, secret: SECRET });
+    const res = makeRes();
+    const next = makeNext();
+    mw(makeReq({ authorization: 'Bearer wrong-token' }), res, next);
+    assert.equal(res._status, 401);
+    assert.deepEqual(res._body, { ok: false, error: 'Unauthorized' });
+    assert.ok(!next.wasCalled());
+  });
+
+  // ── auth enabled, no Authorization header ────────────────────────────────
+
+  it('returns 401 when enabled=true and no Authorization header', () => {
+    process.env.NODE_ENV = 'production';
+    const mw = createAuthMiddleware({ enabled: true, secret: SECRET });
+    const res = makeRes();
+    const next = makeNext();
+    mw(makeReq(), res, next);
+    assert.equal(res._status, 401);
+    assert.deepEqual(res._body, { ok: false, error: 'Unauthorized' });
+    assert.ok(!next.wasCalled());
+  });
+
+  it('returns 401 when Authorization header has wrong scheme', () => {
+    process.env.NODE_ENV = 'production';
+    const mw = createAuthMiddleware({ enabled: true, secret: SECRET });
+    const res = makeRes();
+    const next = makeNext();
+    mw(makeReq({ authorization: `Basic ${SECRET}` }), res, next);
+    assert.equal(res._status, 401);
+    assert.ok(!next.wasCalled());
+  });
+
+  // ── health-check exemption ───────────────────────────────────────────────
+
+  it('passes GET /api/status through even when enabled=true and no token', () => {
+    process.env.NODE_ENV = 'production';
+    // The middleware is mounted at /api, so req.path is /status (not /api/status)
+    const mw = createAuthMiddleware({ enabled: true, secret: SECRET });
+    const next = makeNext();
+    const req = makeReq({ method: 'GET', path: '/status' });
+    mw(req, makeRes(), next);
+    assert.ok(next.wasCalled());
+  });
+
+  it('does NOT exempt POST /api/status from auth', () => {
+    process.env.NODE_ENV = 'production';
+    const mw = createAuthMiddleware({ enabled: true, secret: SECRET });
+    const res = makeRes();
+    const next = makeNext();
+    const req = makeReq({ method: 'POST', path: '/status' });
+    mw(req, res, next);
+    assert.equal(res._status, 401);
+    assert.ok(!next.wasCalled());
+  });
+});

--- a/tests/execution/inter-agent-comm.test.js
+++ b/tests/execution/inter-agent-comm.test.js
@@ -217,6 +217,30 @@ describe('InterAgentComm', () => {
 
       assert.equal(capturedTimers.length, 0);
     });
+
+    it('calls unref on the timeout handle when provided', async () => {
+      let unrefCalled = false;
+      const originalSetTimeout = global.setTimeout;
+      global.setTimeout = (fn, delay) => {
+        return {
+          _fakeTimeout: true,
+          unref() { unrefCalled = true; },
+        };
+      };
+      global.clearTimeout = () => {};
+
+      try {
+        const promise = comm.ask('agent-a', 'agent-b', 'test unref');
+        const taskId = `task-${taskIdCounter}`;
+        setImmediate(() => {
+          eventBus.emit('task.completed', { task: { id: taskId, result: 'ok' } });
+        });
+        await promise;
+        assert.ok(unrefCalled, '.unref() should have been called on the timeout handle');
+      } finally {
+        global.setTimeout = originalSetTimeout;
+      }
+    });
   });
 
   describe('getToolDefinition()', () => {

--- a/tests/execution/inter-agent-comm.test.js
+++ b/tests/execution/inter-agent-comm.test.js
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach } from 'node:test';
+import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { InterAgentComm } from '../../src/execution/inter-agent-comm.js';
 import eventBus from '../../src/core/event-bus.js';
@@ -8,9 +8,25 @@ describe('InterAgentComm', () => {
   let mockTaskQueue;
   let mockOrchestrator;
   let taskIdCounter;
+  let capturedTimers;
+  let originalSetTimeout;
+  let originalClearTimeout;
 
   beforeEach(() => {
     taskIdCounter = 0;
+    capturedTimers = [];
+    originalSetTimeout = global.setTimeout;
+    originalClearTimeout = global.clearTimeout;
+    // Stub setTimeout so ask() does not schedule real long-lived timers.
+    global.setTimeout = (fn, delay) => {
+      const handle = { fn, delay };
+      capturedTimers.push(handle);
+      return handle;
+    };
+    global.clearTimeout = (handle) => {
+      const idx = capturedTimers.indexOf(handle);
+      if (idx !== -1) capturedTimers.splice(idx, 1);
+    };
     mockTaskQueue = {
       add(opts) {
         return { id: `task-${++taskIdCounter}`, ...opts };
@@ -18,6 +34,11 @@ describe('InterAgentComm', () => {
     };
     mockOrchestrator = {};
     comm = new InterAgentComm({ taskQueue: mockTaskQueue, orchestrator: mockOrchestrator });
+  });
+
+  afterEach(() => {
+    global.setTimeout = originalSetTimeout;
+    global.clearTimeout = originalClearTimeout;
   });
 
   describe('constructor', () => {
@@ -33,62 +54,38 @@ describe('InterAgentComm', () => {
 
   describe('ask()', () => {
     it('creates a task with correct defaults', async () => {
-      const originalSetTimeout = global.setTimeout;
-      // Stub setTimeout so InterAgentComm.ask() does not create a long-lived timer.
-      global.setTimeout = (fn, delay, ...args) => {
-        // Do not schedule a real timer; just return a dummy handle.
-        return { _fakeTimeout: true, delay, fn, args };
+      const created = [];
+      comm.taskQueue = {
+        add(opts) {
+          const t = { id: `task-${++taskIdCounter}`, ...opts };
+          created.push(t);
+          return t;
+        },
       };
 
-      try {
-        const created = [];
-        comm.taskQueue = {
-          add(opts) {
-            const t = { id: `task-${++taskIdCounter}`, ...opts };
-            created.push(t);
-            return t;
-          },
-        };
+      const promise = comm.ask('agent-a', 'agent-b', 'What is the answer?');
 
-        const promise = comm.ask('agent-a', 'agent-b', 'What is the answer?');
+      assert.equal(created.length, 1);
+      assert.equal(created[0].title, 'What is the answer?');
+      assert.equal(created[0].type, 'implement');
+      assert.equal(created[0].priority, 'high');
+      assert.equal(created[0].agent_id, 'agent-b');
 
-        assert.equal(created.length, 1);
-        assert.equal(created[0].title, 'What is the answer?');
-        assert.equal(created[0].type, 'implement');
-        assert.equal(created[0].priority, 'high');
-        assert.equal(created[0].agent_id, 'agent-b');
-
-        // Resolve to avoid hanging
-        eventBus.emit('task.completed', { task: created[0] });
-        await promise;
-      } finally {
-        // Restore the original setTimeout after the test completes.
-        global.setTimeout = originalSetTimeout;
-      }
+      // Resolve to avoid hanging
+      eventBus.emit('task.completed', { task: created[0] });
+      await promise;
     });
 
     it('resolves with task result when task.completed fires', async () => {
-      const originalSetTimeout = global.setTimeout;
-      // Stub setTimeout so InterAgentComm.ask() does not create a long-lived timer.
-      global.setTimeout = (fn, delay, ...args) => {
-        // Do not schedule a real timer; just return a dummy handle.
-        return { _fakeTimeout: true, delay, fn, args };
-      };
+      const promise = comm.ask('agent-a', 'agent-b', 'Do something');
+      const taskId = `task-${taskIdCounter}`;
 
-      try {
-        const promise = comm.ask('agent-a', 'agent-b', 'Do something');
-        const taskId = `task-${taskIdCounter}`;
+      setImmediate(() => {
+        eventBus.emit('task.completed', { task: { id: taskId, result: 'done result' } });
+      });
 
-        setImmediate(() => {
-          eventBus.emit('task.completed', { task: { id: taskId, result: 'done result' } });
-        });
-
-        const result = await promise;
-        assert.equal(result, 'done result');
-      } finally {
-        // Restore the original setTimeout after the test completes.
-        global.setTimeout = originalSetTimeout;
-      }
+      const result = await promise;
+      assert.equal(result, 'done result');
     });
 
     it('resolves with empty string when task result is undefined', async () => {
@@ -182,6 +179,43 @@ describe('InterAgentComm', () => {
 
       await promise.catch(() => {});
       assert.equal(comm.pendingCount(), 0);
+    });
+
+    it('rejects with timeout error when timer fires', async () => {
+      const promise = comm.ask('agent-a', 'agent-b', 'Q');
+
+      assert.equal(capturedTimers.length, 1);
+      assert.equal(capturedTimers[0].delay, 5 * 60 * 1000);
+
+      // Fire the timeout callback synchronously
+      capturedTimers[0].fn();
+
+      await assert.rejects(promise, /ask_agent timeout/);
+      assert.equal(comm.pendingCount(), 0);
+    });
+
+    it('clears timeout when task completes', async () => {
+      const promise = comm.ask('agent-a', 'agent-b', 'Q');
+      const taskId = `task-${taskIdCounter}`;
+
+      assert.equal(capturedTimers.length, 1);
+
+      eventBus.emit('task.completed', { task: { id: taskId, result: 'done' } });
+      await promise;
+
+      assert.equal(capturedTimers.length, 0);
+    });
+
+    it('clears timeout when task fails', async () => {
+      const promise = comm.ask('agent-a', 'agent-b', 'Q');
+      const taskId = `task-${taskIdCounter}`;
+
+      assert.equal(capturedTimers.length, 1);
+
+      eventBus.emit('task.failed', { task: { id: taskId }, error: 'boom' });
+      await promise.catch(() => {});
+
+      assert.equal(capturedTimers.length, 0);
     });
   });
 

--- a/tests/execution/inter-agent-comm.test.js
+++ b/tests/execution/inter-agent-comm.test.js
@@ -33,38 +33,62 @@ describe('InterAgentComm', () => {
 
   describe('ask()', () => {
     it('creates a task with correct defaults', async () => {
-      const created = [];
-      comm.taskQueue = {
-        add(opts) {
-          const t = { id: `task-${++taskIdCounter}`, ...opts };
-          created.push(t);
-          return t;
-        },
+      const originalSetTimeout = global.setTimeout;
+      // Stub setTimeout so InterAgentComm.ask() does not create a long-lived timer.
+      global.setTimeout = (fn, delay, ...args) => {
+        // Do not schedule a real timer; just return a dummy handle.
+        return { _fakeTimeout: true, delay, fn, args };
       };
 
-      const promise = comm.ask('agent-a', 'agent-b', 'What is the answer?');
+      try {
+        const created = [];
+        comm.taskQueue = {
+          add(opts) {
+            const t = { id: `task-${++taskIdCounter}`, ...opts };
+            created.push(t);
+            return t;
+          },
+        };
 
-      assert.equal(created.length, 1);
-      assert.equal(created[0].title, 'What is the answer?');
-      assert.equal(created[0].type, 'implement');
-      assert.equal(created[0].priority, 'high');
-      assert.equal(created[0].agent_id, 'agent-b');
+        const promise = comm.ask('agent-a', 'agent-b', 'What is the answer?');
 
-      // Resolve to avoid hanging
-      eventBus.emit('task.completed', { task: created[0] });
-      await promise;
+        assert.equal(created.length, 1);
+        assert.equal(created[0].title, 'What is the answer?');
+        assert.equal(created[0].type, 'implement');
+        assert.equal(created[0].priority, 'high');
+        assert.equal(created[0].agent_id, 'agent-b');
+
+        // Resolve to avoid hanging
+        eventBus.emit('task.completed', { task: created[0] });
+        await promise;
+      } finally {
+        // Restore the original setTimeout after the test completes.
+        global.setTimeout = originalSetTimeout;
+      }
     });
 
     it('resolves with task result when task.completed fires', async () => {
-      const promise = comm.ask('agent-a', 'agent-b', 'Do something');
-      const taskId = `task-${taskIdCounter}`;
+      const originalSetTimeout = global.setTimeout;
+      // Stub setTimeout so InterAgentComm.ask() does not create a long-lived timer.
+      global.setTimeout = (fn, delay, ...args) => {
+        // Do not schedule a real timer; just return a dummy handle.
+        return { _fakeTimeout: true, delay, fn, args };
+      };
 
-      setImmediate(() => {
-        eventBus.emit('task.completed', { task: { id: taskId, result: 'done result' } });
-      });
+      try {
+        const promise = comm.ask('agent-a', 'agent-b', 'Do something');
+        const taskId = `task-${taskIdCounter}`;
 
-      const result = await promise;
-      assert.equal(result, 'done result');
+        setImmediate(() => {
+          eventBus.emit('task.completed', { task: { id: taskId, result: 'done result' } });
+        });
+
+        const result = await promise;
+        assert.equal(result, 'done result');
+      } finally {
+        // Restore the original setTimeout after the test completes.
+        global.setTimeout = originalSetTimeout;
+      }
     });
 
     it('resolves with empty string when task result is undefined', async () => {

--- a/tests/execution/inter-agent-comm.test.js
+++ b/tests/execution/inter-agent-comm.test.js
@@ -1,0 +1,201 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { InterAgentComm } from '../../src/execution/inter-agent-comm.js';
+import eventBus from '../../src/core/event-bus.js';
+
+describe('InterAgentComm', () => {
+  let comm;
+  let mockTaskQueue;
+  let mockOrchestrator;
+  let taskIdCounter;
+
+  beforeEach(() => {
+    taskIdCounter = 0;
+    mockTaskQueue = {
+      add(opts) {
+        return { id: `task-${++taskIdCounter}`, ...opts };
+      },
+    };
+    mockOrchestrator = {};
+    comm = new InterAgentComm({ taskQueue: mockTaskQueue, orchestrator: mockOrchestrator });
+  });
+
+  describe('constructor', () => {
+    it('initialises with empty pending map', () => {
+      assert.equal(comm.pendingCount(), 0);
+    });
+
+    it('stores taskQueue and orchestrator references', () => {
+      assert.equal(comm.taskQueue, mockTaskQueue);
+      assert.equal(comm.orchestrator, mockOrchestrator);
+    });
+  });
+
+  describe('ask()', () => {
+    it('creates a task with correct defaults', async () => {
+      const created = [];
+      comm.taskQueue = {
+        add(opts) {
+          const t = { id: `task-${++taskIdCounter}`, ...opts };
+          created.push(t);
+          return t;
+        },
+      };
+
+      const promise = comm.ask('agent-a', 'agent-b', 'What is the answer?');
+
+      assert.equal(created.length, 1);
+      assert.equal(created[0].title, 'What is the answer?');
+      assert.equal(created[0].type, 'implement');
+      assert.equal(created[0].priority, 'high');
+      assert.equal(created[0].agent_id, 'agent-b');
+
+      // Resolve to avoid hanging
+      eventBus.emit('task.completed', { task: created[0] });
+      await promise;
+    });
+
+    it('resolves with task result when task.completed fires', async () => {
+      const promise = comm.ask('agent-a', 'agent-b', 'Do something');
+      const taskId = `task-${taskIdCounter}`;
+
+      setImmediate(() => {
+        eventBus.emit('task.completed', { task: { id: taskId, result: 'done result' } });
+      });
+
+      const result = await promise;
+      assert.equal(result, 'done result');
+    });
+
+    it('resolves with empty string when task result is undefined', async () => {
+      const promise = comm.ask('agent-a', 'agent-b', 'Do something');
+      const taskId = `task-${taskIdCounter}`;
+
+      setImmediate(() => {
+        eventBus.emit('task.completed', { task: { id: taskId } });
+      });
+
+      const result = await promise;
+      assert.equal(result, '');
+    });
+
+    it('rejects when task.failed fires', async () => {
+      const promise = comm.ask('agent-a', 'agent-b', 'Do something');
+      const taskId = `task-${taskIdCounter}`;
+
+      setImmediate(() => {
+        eventBus.emit('task.failed', { task: { id: taskId }, error: 'something went wrong' });
+      });
+
+      await assert.rejects(promise, /something went wrong/);
+    });
+
+    it('ignores events for other task IDs', async () => {
+      const promise = comm.ask('agent-a', 'agent-b', 'Do something');
+      const taskId = `task-${taskIdCounter}`;
+
+      setImmediate(() => {
+        // Emit for a different task first — should be ignored
+        eventBus.emit('task.completed', { task: { id: 'other-task', result: 'wrong' } });
+        // Then emit for the correct task
+        eventBus.emit('task.completed', { task: { id: taskId, result: 'correct' } });
+      });
+
+      const result = await promise;
+      assert.equal(result, 'correct');
+    });
+
+    it('forwards optional opts to the task', async () => {
+      const created = [];
+      comm.taskQueue = {
+        add(opts) {
+          const t = { id: `task-${++taskIdCounter}`, ...opts };
+          created.push(t);
+          return t;
+        },
+      };
+
+      const ctx = { extra: 'data' };
+      const promise = comm.ask('agent-a', 'agent-b', 'Q', {
+        type: 'review',
+        priority: 'low',
+        project_id: 'proj-1',
+        context: ctx,
+      });
+
+      assert.equal(created[0].type, 'review');
+      assert.equal(created[0].priority, 'low');
+      assert.equal(created[0].project_id, 'proj-1');
+      assert.deepEqual(created[0].context, ctx);
+
+      eventBus.emit('task.completed', { task: created[0] });
+      await promise;
+    });
+
+    it('removes pending entry after resolution', async () => {
+      const promise = comm.ask('agent-a', 'agent-b', 'Q');
+      const taskId = `task-${taskIdCounter}`;
+
+      assert.equal(comm.pendingCount(), 1);
+
+      setImmediate(() => {
+        eventBus.emit('task.completed', { task: { id: taskId, result: 'ok' } });
+      });
+
+      await promise;
+      assert.equal(comm.pendingCount(), 0);
+    });
+
+    it('removes pending entry after rejection', async () => {
+      const promise = comm.ask('agent-a', 'agent-b', 'Q');
+      const taskId = `task-${taskIdCounter}`;
+
+      assert.equal(comm.pendingCount(), 1);
+
+      setImmediate(() => {
+        eventBus.emit('task.failed', { task: { id: taskId }, error: 'boom' });
+      });
+
+      await promise.catch(() => {});
+      assert.equal(comm.pendingCount(), 0);
+    });
+  });
+
+  describe('getToolDefinition()', () => {
+    it('returns a valid tool definition object', () => {
+      const def = comm.getToolDefinition();
+      assert.equal(def.name, 'ask_agent');
+      assert.equal(typeof def.description, 'string');
+      assert.ok(def.description.length > 0);
+    });
+
+    it('has required input_schema with agent_id and question', () => {
+      const { input_schema } = comm.getToolDefinition();
+      assert.equal(input_schema.type, 'object');
+      assert.ok('agent_id' in input_schema.properties);
+      assert.ok('question' in input_schema.properties);
+      assert.deepEqual(input_schema.required, ['agent_id', 'question']);
+    });
+
+    it('includes priority as optional enum property', () => {
+      const { input_schema } = comm.getToolDefinition();
+      const priority = input_schema.properties.priority;
+      assert.equal(priority.type, 'string');
+      assert.deepEqual(priority.enum, ['high', 'medium', 'low']);
+    });
+  });
+
+  describe('pendingCount()', () => {
+    it('tracks multiple concurrent requests', async () => {
+      const p1 = comm.ask('a', 'b', 'Q1');
+      const p2 = comm.ask('a', 'c', 'Q2');
+      assert.equal(comm.pendingCount(), 2);
+
+      eventBus.emit('task.completed', { task: { id: 'task-1', result: '' } });
+      eventBus.emit('task.completed', { task: { id: 'task-2', result: '' } });
+
+      await Promise.all([p1, p2]);
+      assert.equal(comm.pendingCount(), 0);
+    });
+  });
+});

--- a/tests/execution/inter-agent-comm.test.js
+++ b/tests/execution/inter-agent-comm.test.js
@@ -1,283 +1,235 @@
+/**
+ * @file tests/execution/inter-agent-comm.test.js
+ * @description Unit tests for src/execution/inter-agent-comm.js
+ *
+ * Covers:
+ *  - getToolDefinition() returns correct Anthropic tool schema
+ *  - pendingCount() starts at 0
+ *  - ask() creates a task via taskQueue.add() with correct fields
+ *  - ask() resolves with task.result when task.completed fires
+ *  - ask() resolves with '' when result is undefined
+ *  - ask() rejects when task.failed fires
+ *  - ask() ignores events for unrelated task IDs
+ *  - pendingCount() increments while pending, returns to 0 after resolve/reject
+ *
+ * Note: ask() sets a 5-minute liveness timeout.  We wrap globalThis.setTimeout
+ * to automatically unref() long timers so they don't block process exit.
+ */
+
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { InterAgentComm } from '../../src/execution/inter-agent-comm.js';
 import eventBus from '../../src/core/event-bus.js';
+import { InterAgentComm } from '../../src/execution/inter-agent-comm.js';
+
+// ---------------------------------------------------------------------------
+// Suppress long timers so the test process can exit cleanly.
+// ask() schedules a 5-minute timeout; we let it run but unref() it so it
+// does not prevent the event loop from draining after tests complete.
+// ---------------------------------------------------------------------------
+const _origSetTimeout = globalThis.setTimeout;
+globalThis.setTimeout = function patchedSetTimeout(fn, delay, ...args) {
+  const timer = _origSetTimeout.call(this, fn, delay, ...args);
+  if (delay >= 60_000 && timer && typeof timer.unref === 'function') {
+    timer.unref();
+  }
+  return timer;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let _taskIdCounter = 0;
+
+/** Minimal TaskQueue stub. */
+function makeTaskQueue() {
+  const added = [];
+  return {
+    added,
+    add(spec) {
+      const task = { ...spec, id: `task-${++_taskIdCounter}` };
+      added.push(task);
+      return task;
+    },
+  };
+}
+
+const fakeOrchestrator = {};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 describe('InterAgentComm', () => {
-  let comm;
-  let mockTaskQueue;
-  let mockOrchestrator;
-  let taskIdCounter;
-  let capturedTimers;
-  let originalSetTimeout;
-  let originalClearTimeout;
+  let taskQueue, comm;
 
   beforeEach(() => {
-    taskIdCounter = 0;
-    capturedTimers = [];
-    originalSetTimeout = global.setTimeout;
-    originalClearTimeout = global.clearTimeout;
-    // Stub setTimeout so ask() does not schedule real long-lived timers.
-    global.setTimeout = (fn, delay) => {
-      const handle = { fn, delay };
-      capturedTimers.push(handle);
-      return handle;
-    };
-    global.clearTimeout = (handle) => {
-      const idx = capturedTimers.indexOf(handle);
-      if (idx !== -1) capturedTimers.splice(idx, 1);
-    };
-    mockTaskQueue = {
-      add(opts) {
-        return { id: `task-${++taskIdCounter}`, ...opts };
-      },
-    };
-    mockOrchestrator = {};
-    comm = new InterAgentComm({ taskQueue: mockTaskQueue, orchestrator: mockOrchestrator });
+    eventBus._log = [];
+    taskQueue = makeTaskQueue();
+    comm = new InterAgentComm({ taskQueue, orchestrator: fakeOrchestrator });
   });
 
   afterEach(() => {
-    global.setTimeout = originalSetTimeout;
-    global.clearTimeout = originalClearTimeout;
+    eventBus.removeAllListeners('task.completed');
+    eventBus.removeAllListeners('task.failed');
   });
 
-  describe('constructor', () => {
-    it('initialises with empty pending map', () => {
-      assert.equal(comm.pendingCount(), 0);
-    });
+  // ── getToolDefinition() ───────────────────────────────────────────────────
 
-    it('stores taskQueue and orchestrator references', () => {
-      assert.equal(comm.taskQueue, mockTaskQueue);
-      assert.equal(comm.orchestrator, mockOrchestrator);
-    });
+  it('getToolDefinition() returns name "ask_agent"', () => {
+    const def = comm.getToolDefinition();
+    assert.equal(def.name, 'ask_agent');
   });
 
-  describe('ask()', () => {
-    it('creates a task with correct defaults', async () => {
-      const created = [];
-      comm.taskQueue = {
-        add(opts) {
-          const t = { id: `task-${++taskIdCounter}`, ...opts };
-          created.push(t);
-          return t;
-        },
-      };
-
-      const promise = comm.ask('agent-a', 'agent-b', 'What is the answer?');
-
-      assert.equal(created.length, 1);
-      assert.equal(created[0].title, 'What is the answer?');
-      assert.equal(created[0].type, 'implement');
-      assert.equal(created[0].priority, 'high');
-      assert.equal(created[0].agent_id, 'agent-b');
-
-      // Resolve to avoid hanging
-      eventBus.emit('task.completed', { task: created[0] });
-      await promise;
-    });
-
-    it('resolves with task result when task.completed fires', async () => {
-      const promise = comm.ask('agent-a', 'agent-b', 'Do something');
-      const taskId = `task-${taskIdCounter}`;
-
-      setImmediate(() => {
-        eventBus.emit('task.completed', { task: { id: taskId, result: 'done result' } });
-      });
-
-      const result = await promise;
-      assert.equal(result, 'done result');
-    });
-
-    it('resolves with empty string when task result is undefined', async () => {
-      const promise = comm.ask('agent-a', 'agent-b', 'Do something');
-      const taskId = `task-${taskIdCounter}`;
-
-      setImmediate(() => {
-        eventBus.emit('task.completed', { task: { id: taskId } });
-      });
-
-      const result = await promise;
-      assert.equal(result, '');
-    });
-
-    it('rejects when task.failed fires', async () => {
-      const promise = comm.ask('agent-a', 'agent-b', 'Do something');
-      const taskId = `task-${taskIdCounter}`;
-
-      setImmediate(() => {
-        eventBus.emit('task.failed', { task: { id: taskId }, error: 'something went wrong' });
-      });
-
-      await assert.rejects(promise, /something went wrong/);
-    });
-
-    it('ignores events for other task IDs', async () => {
-      const promise = comm.ask('agent-a', 'agent-b', 'Do something');
-      const taskId = `task-${taskIdCounter}`;
-
-      setImmediate(() => {
-        // Emit for a different task first — should be ignored
-        eventBus.emit('task.completed', { task: { id: 'other-task', result: 'wrong' } });
-        // Then emit for the correct task
-        eventBus.emit('task.completed', { task: { id: taskId, result: 'correct' } });
-      });
-
-      const result = await promise;
-      assert.equal(result, 'correct');
-    });
-
-    it('forwards optional opts to the task', async () => {
-      const created = [];
-      comm.taskQueue = {
-        add(opts) {
-          const t = { id: `task-${++taskIdCounter}`, ...opts };
-          created.push(t);
-          return t;
-        },
-      };
-
-      const ctx = { extra: 'data' };
-      const promise = comm.ask('agent-a', 'agent-b', 'Q', {
-        type: 'review',
-        priority: 'low',
-        project_id: 'proj-1',
-        context: ctx,
-      });
-
-      assert.equal(created[0].type, 'review');
-      assert.equal(created[0].priority, 'low');
-      assert.equal(created[0].project_id, 'proj-1');
-      assert.deepEqual(created[0].context, ctx);
-
-      eventBus.emit('task.completed', { task: created[0] });
-      await promise;
-    });
-
-    it('removes pending entry after resolution', async () => {
-      const promise = comm.ask('agent-a', 'agent-b', 'Q');
-      const taskId = `task-${taskIdCounter}`;
-
-      assert.equal(comm.pendingCount(), 1);
-
-      setImmediate(() => {
-        eventBus.emit('task.completed', { task: { id: taskId, result: 'ok' } });
-      });
-
-      await promise;
-      assert.equal(comm.pendingCount(), 0);
-    });
-
-    it('removes pending entry after rejection', async () => {
-      const promise = comm.ask('agent-a', 'agent-b', 'Q');
-      const taskId = `task-${taskIdCounter}`;
-
-      assert.equal(comm.pendingCount(), 1);
-
-      setImmediate(() => {
-        eventBus.emit('task.failed', { task: { id: taskId }, error: 'boom' });
-      });
-
-      await promise.catch(() => {});
-      assert.equal(comm.pendingCount(), 0);
-    });
-
-    it('rejects with timeout error when timer fires', async () => {
-      const promise = comm.ask('agent-a', 'agent-b', 'Q');
-
-      assert.equal(capturedTimers.length, 1);
-      assert.equal(capturedTimers[0].delay, 5 * 60 * 1000);
-
-      // Fire the timeout callback synchronously
-      capturedTimers[0].fn();
-
-      await assert.rejects(promise, /ask_agent timeout/);
-      assert.equal(comm.pendingCount(), 0);
-    });
-
-    it('clears timeout when task completes', async () => {
-      const promise = comm.ask('agent-a', 'agent-b', 'Q');
-      const taskId = `task-${taskIdCounter}`;
-
-      assert.equal(capturedTimers.length, 1);
-
-      eventBus.emit('task.completed', { task: { id: taskId, result: 'done' } });
-      await promise;
-
-      assert.equal(capturedTimers.length, 0);
-    });
-
-    it('clears timeout when task fails', async () => {
-      const promise = comm.ask('agent-a', 'agent-b', 'Q');
-      const taskId = `task-${taskIdCounter}`;
-
-      assert.equal(capturedTimers.length, 1);
-
-      eventBus.emit('task.failed', { task: { id: taskId }, error: 'boom' });
-      await promise.catch(() => {});
-
-      assert.equal(capturedTimers.length, 0);
-    });
-
-    it('calls unref on the timeout handle when provided', async () => {
-      let unrefCalled = false;
-      const originalSetTimeout = global.setTimeout;
-      global.setTimeout = (fn, delay) => {
-        return {
-          _fakeTimeout: true,
-          unref() { unrefCalled = true; },
-        };
-      };
-      global.clearTimeout = () => {};
-
-      try {
-        const promise = comm.ask('agent-a', 'agent-b', 'test unref');
-        const taskId = `task-${taskIdCounter}`;
-        setImmediate(() => {
-          eventBus.emit('task.completed', { task: { id: taskId, result: 'ok' } });
-        });
-        await promise;
-        assert.ok(unrefCalled, '.unref() should have been called on the timeout handle');
-      } finally {
-        global.setTimeout = originalSetTimeout;
-      }
-    });
+  it('getToolDefinition() schema requires agent_id and question', () => {
+    const { input_schema } = comm.getToolDefinition();
+    assert.ok(input_schema.properties, 'properties missing');
+    assert.deepEqual(input_schema.required, ['agent_id', 'question']);
   });
 
-  describe('getToolDefinition()', () => {
-    it('returns a valid tool definition object', () => {
-      const def = comm.getToolDefinition();
-      assert.equal(def.name, 'ask_agent');
-      assert.equal(typeof def.description, 'string');
-      assert.ok(def.description.length > 0);
-    });
-
-    it('has required input_schema with agent_id and question', () => {
-      const { input_schema } = comm.getToolDefinition();
-      assert.equal(input_schema.type, 'object');
-      assert.ok('agent_id' in input_schema.properties);
-      assert.ok('question' in input_schema.properties);
-      assert.deepEqual(input_schema.required, ['agent_id', 'question']);
-    });
-
-    it('includes priority as optional enum property', () => {
-      const { input_schema } = comm.getToolDefinition();
-      const priority = input_schema.properties.priority;
-      assert.equal(priority.type, 'string');
-      assert.deepEqual(priority.enum, ['high', 'medium', 'low']);
-    });
+  it('getToolDefinition() includes priority enum with high/medium/low', () => {
+    const { input_schema } = comm.getToolDefinition();
+    assert.deepEqual(input_schema.properties.priority.enum, ['high', 'medium', 'low']);
   });
 
-  describe('pendingCount()', () => {
-    it('tracks multiple concurrent requests', async () => {
-      const p1 = comm.ask('a', 'b', 'Q1');
-      const p2 = comm.ask('a', 'c', 'Q2');
-      assert.equal(comm.pendingCount(), 2);
+  // ── pendingCount() ────────────────────────────────────────────────────────
 
-      eventBus.emit('task.completed', { task: { id: 'task-1', result: '' } });
-      eventBus.emit('task.completed', { task: { id: 'task-2', result: '' } });
+  it('pendingCount() is 0 before any asks', () => {
+    assert.equal(comm.pendingCount(), 0);
+  });
 
-      await Promise.all([p1, p2]);
-      assert.equal(comm.pendingCount(), 0);
+  // ── ask() — task creation ─────────────────────────────────────────────────
+
+  it('ask() calls taskQueue.add() with title, type, priority, agent_id, project_id', async () => {
+    process.nextTick(() => {
+      const task = taskQueue.added[0];
+      if (task) eventBus.emit('task.completed', { task: { ...task, result: 'ok' } });
     });
+
+    await comm.ask('agent-a', 'agent-b', 'What is X?', {
+      type: 'review',
+      priority: 'low',
+      project_id: 'proj-1',
+    });
+
+    const added = taskQueue.added[0];
+    assert.equal(added.title, 'What is X?');
+    assert.equal(added.type, 'review');
+    assert.equal(added.priority, 'low');
+    assert.equal(added.agent_id, 'agent-b');
+    assert.equal(added.project_id, 'proj-1');
+  });
+
+  it('ask() defaults type to "implement" and priority to "high"', async () => {
+    process.nextTick(() => {
+      const task = taskQueue.added[0];
+      if (task) eventBus.emit('task.completed', { task: { ...task, result: '' } });
+    });
+
+    await comm.ask('from', 'to', 'Do thing');
+
+    const added = taskQueue.added[0];
+    assert.equal(added.type, 'implement');
+    assert.equal(added.priority, 'high');
+  });
+
+  // ── ask() — resolution paths ──────────────────────────────────────────────
+
+  it('ask() resolves with task.result on task.completed', async () => {
+    process.nextTick(() => {
+      const task = taskQueue.added[0];
+      eventBus.emit('task.completed', { task: { ...task, result: 'the answer' } });
+    });
+
+    const result = await comm.ask('a', 'b', 'Q?');
+    assert.equal(result, 'the answer');
+  });
+
+  it('ask() resolves with "" when task.result is undefined', async () => {
+    process.nextTick(() => {
+      const task = taskQueue.added[0];
+      eventBus.emit('task.completed', { task: { ...task } });
+    });
+
+    const result = await comm.ask('a', 'b', 'No result');
+    assert.equal(result, '');
+  });
+
+  it('ask() rejects with Error containing the error message on task.failed', async () => {
+    process.nextTick(() => {
+      const task = taskQueue.added[0];
+      eventBus.emit('task.failed', { task, error: 'Provider unavailable' });
+    });
+
+    await assert.rejects(
+      () => comm.ask('a', 'b', 'Failing task'),
+      /Provider unavailable/,
+    );
+  });
+
+  // ── ask() — event isolation ───────────────────────────────────────────────
+
+  it('ask() ignores task.completed for a different task ID', async () => {
+    let resolved = false;
+    const p = comm.ask('a', 'b', 'Isolated?').then(() => { resolved = true; });
+
+    // Emit for an unrelated task
+    eventBus.emit('task.completed', { task: { id: 'unrelated-id-xyz', result: 'noise' } });
+
+    await new Promise((r) => setTimeout(r, 20));
+    assert.equal(resolved, false, 'should not have resolved');
+
+    // Resolve with the correct task
+    const task = taskQueue.added[0];
+    eventBus.emit('task.completed', { task: { ...task, result: 'real' } });
+    await p;
+    assert.equal(resolved, true);
+  });
+
+  it('ask() ignores task.failed for a different task ID', async () => {
+    let rejected = false;
+    const p = comm.ask('a', 'b', 'Safe?').catch(() => { rejected = true; });
+
+    eventBus.emit('task.failed', { task: { id: 'other-id-xyz' }, error: 'noise' });
+
+    await new Promise((r) => setTimeout(r, 20));
+    assert.equal(rejected, false, 'should not have rejected');
+
+    const task = taskQueue.added[0];
+    eventBus.emit('task.completed', { task: { ...task, result: '' } });
+    await p;
+  });
+
+  // ── ask() — pending count lifecycle ──────────────────────────────────────
+
+  it('pendingCount() is 1 while ask() is in flight', () => {
+    // Don't resolve yet
+    const p = comm.ask('a', 'b', 'pending check').catch(() => {});
+    assert.equal(comm.pendingCount(), 1);
+
+    // Resolve to unblock
+    const task = taskQueue.added[0];
+    eventBus.emit('task.completed', { task: { ...task, result: '' } });
+    return p;
+  });
+
+  it('pendingCount() returns to 0 after task.completed', async () => {
+    process.nextTick(() => {
+      const task = taskQueue.added[0];
+      eventBus.emit('task.completed', { task: { ...task, result: 'done' } });
+    });
+
+    await comm.ask('a', 'b', 'cleanup on complete');
+    assert.equal(comm.pendingCount(), 0);
+  });
+
+  it('pendingCount() returns to 0 after task.failed', async () => {
+    process.nextTick(() => {
+      const task = taskQueue.added[0];
+      eventBus.emit('task.failed', { task, error: 'oops' });
+    });
+
+    await comm.ask('a', 'b', 'cleanup on fail').catch(() => {});
+    assert.equal(comm.pendingCount(), 0);
   });
 });

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1980,6 +1980,70 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.1.tgz",
@@ -3049,9 +3113,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,27 +1,44 @@
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Navigate, Outlet, useLocation } from 'react-router-dom'
 import { WebSocketProvider } from '@/contexts/WebSocketContext'
+import { AuthProvider, useAuth } from '@/contexts/AuthContext'
 import { Layout } from '@/components/layout/Layout'
 import DashboardView from '@/views/DashboardView'
 import KanbanView from '@/views/KanbanView'
 import AgentsView from '@/views/AgentsView'
 import ProvidersView from '@/views/ProvidersView'
 import CostsView from '@/views/CostsView'
+import LoginView from '@/views/LoginView'
+
+function ProtectedRoute() {
+  const { isAuthenticated } = useAuth()
+  const location = useLocation()
+  if (!isAuthenticated) {
+    const redirect = location.pathname + location.search
+    return <Navigate to={`/login?redirect=${encodeURIComponent(redirect)}`} replace />
+  }
+  return <Outlet />
+}
 
 export default function App() {
   return (
     <BrowserRouter>
-      <WebSocketProvider>
-        <Routes>
-          <Route element={<Layout />}>
-            <Route index element={<Navigate to="/dashboard" replace />} />
-            <Route path="/dashboard" element={<DashboardView />} />
-            <Route path="/kanban" element={<KanbanView />} />
-            <Route path="/agents" element={<AgentsView />} />
-            <Route path="/providers" element={<ProvidersView />} />
-            <Route path="/costs" element={<CostsView />} />
-          </Route>
-        </Routes>
-      </WebSocketProvider>
+      <AuthProvider>
+        <WebSocketProvider>
+          <Routes>
+            <Route path="/login" element={<LoginView />} />
+            <Route element={<ProtectedRoute />}>
+              <Route element={<Layout />}>
+                <Route index element={<Navigate to="/dashboard" replace />} />
+                <Route path="/dashboard" element={<DashboardView />} />
+                <Route path="/kanban" element={<KanbanView />} />
+                <Route path="/agents" element={<AgentsView />} />
+                <Route path="/providers" element={<ProvidersView />} />
+                <Route path="/costs" element={<CostsView />} />
+              </Route>
+            </Route>
+          </Routes>
+        </WebSocketProvider>
+      </AuthProvider>
     </BrowserRouter>
   )
 }

--- a/ui/src/components/ui/checkbox.tsx
+++ b/ui/src/components/ui/checkbox.tsx
@@ -1,0 +1,29 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export interface CheckboxProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  onCheckedChange?: (checked: boolean) => void
+}
+
+const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
+  ({ className, onCheckedChange, onChange, ...props }, ref) => {
+    return (
+      <input
+        type="checkbox"
+        className={cn(
+          "h-4 w-4 rounded border border-input bg-transparent shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        onChange={(e) => {
+          onChange?.(e)
+          onCheckedChange?.(e.target.checked)
+        }}
+        {...props}
+      />
+    )
+  }
+)
+Checkbox.displayName = "Checkbox"
+
+export { Checkbox }

--- a/ui/src/components/ui/input.tsx
+++ b/ui/src/components/ui/input.tsx
@@ -1,0 +1,23 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/ui/src/components/ui/label.tsx
+++ b/ui/src/components/ui/label.tsx
@@ -1,0 +1,19 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+const Label = React.forwardRef<
+  HTMLLabelElement,
+  React.LabelHTMLAttributes<HTMLLabelElement>
+>(({ className, ...props }, ref) => (
+  <label
+    ref={ref}
+    className={cn(
+      "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+      className
+    )}
+    {...props}
+  />
+))
+Label.displayName = "Label"
+
+export { Label }

--- a/ui/src/contexts/AuthContext.tsx
+++ b/ui/src/contexts/AuthContext.tsx
@@ -1,0 +1,140 @@
+import { createContext, useContext, useEffect, useState, useCallback } from 'react'
+import { setUnauthorizedHandler } from '@/lib/api'
+import { setWsUnauthorizedHandler } from '@/lib/ws'
+
+interface AuthContextValue {
+  token: string | null
+  isAuthenticated: boolean
+  login: (token: string, remember: boolean) => Promise<void>
+  logout: () => void
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  token: null,
+  isAuthenticated: false,
+  login: async () => {},
+  logout: () => {},
+})
+
+// Module-level token storage for use outside React tree (e.g. in api.ts)
+let _token: string | null = null
+
+export function getToken(): string | null {
+  return _token
+}
+
+function readStoredToken(): string | null {
+  return localStorage.getItem('agentforge_token') ?? sessionStorage.getItem('agentforge_token')
+}
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [token, setToken] = useState<string | null>(() => {
+    const stored = readStoredToken()
+    _token = stored
+    return stored
+  })
+  const [isAuthenticated, setIsAuthenticated] = useState(false)
+  const [checking, setChecking] = useState(true)
+
+  const logout = useCallback(() => {
+    _token = null
+    setToken(null)
+    setIsAuthenticated(false)
+    localStorage.removeItem('agentforge_token')
+    sessionStorage.removeItem('agentforge_token')
+    window.location.href = '/login'
+  }, [])
+
+  // Register the 401 handler so api.ts can call logout
+  useEffect(() => {
+    setUnauthorizedHandler(logout)
+    setWsUnauthorizedHandler(logout)
+  }, [logout])
+
+  // On mount: check if auth is even required (auth_enabled bypass),
+  // or restore token from storage.
+  useEffect(() => {
+    async function checkAuth() {
+      try {
+        const res = await fetch('/api/status')
+        if (res.ok) {
+          const data = await res.json() as { auth_enabled?: boolean }
+          if (data.auth_enabled === false || !Object.prototype.hasOwnProperty.call(data, 'auth_enabled')) {
+            // Auth disabled or status returned 200 without a token — bypass login
+            // Keep any stored token in _token (or leave null); no auth header needed
+            _token = token
+            setIsAuthenticated(true)
+            setChecking(false)
+            return
+          }
+        }
+      } catch {
+        // Network error — fall through to token-based check
+      }
+
+      // Auth is enabled; check stored token
+      if (token) {
+        try {
+          const res = await fetch('/api/status', {
+            headers: { Authorization: `Bearer ${token}` },
+          })
+          if (res.ok) {
+            _token = token
+            setIsAuthenticated(true)
+          } else {
+            // Stored token is no longer valid
+            _token = null
+            setToken(null)
+            setIsAuthenticated(false)
+            localStorage.removeItem('agentforge_token')
+            sessionStorage.removeItem('agentforge_token')
+          }
+        } catch {
+          // Network error — keep token, assume authenticated for now
+          _token = token
+          setIsAuthenticated(true)
+        }
+      }
+      setChecking(false)
+    }
+
+    void checkAuth()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const login = useCallback(async (newToken: string, remember: boolean) => {
+    const res = await fetch('/api/status', {
+      headers: newToken ? { Authorization: `Bearer ${newToken}` } : {},
+    })
+    if (!res.ok) {
+      throw new Error('Invalid token')
+    }
+    _token = newToken
+    setToken(newToken)
+    setIsAuthenticated(true)
+    if (remember) {
+      localStorage.setItem('agentforge_token', newToken)
+    } else {
+      sessionStorage.setItem('agentforge_token', newToken)
+    }
+  }, [])
+
+  // While we're checking auth state, render a minimal spinner (avoids flash of login page)
+  if (checking) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background">
+        <div className="h-8 w-8 rounded-full border-2 border-muted border-t-foreground animate-spin" />
+      </div>
+    )
+  }
+
+  return (
+    <AuthContext.Provider value={{ token, isAuthenticated, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  return useContext(AuthContext)
+}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1,10 +1,34 @@
+import { getToken } from '@/contexts/AuthContext'
+
 const BASE = '/api'
 
+// Module-level callback invoked when a 401 response is received
+let onUnauthorized: (() => void) | null = null
+
+export function setUnauthorizedHandler(fn: () => void) {
+  onUnauthorized = fn
+}
+
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
+  const token = getToken()
+  const authHeaders: Record<string, string> = token
+    ? { Authorization: `Bearer ${token}` }
+    : {}
+
   const res = await fetch(`${BASE}${path}`, {
-    headers: { 'Content-Type': 'application/json' },
     ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeaders,
+      ...(options?.headers as Record<string, string> | undefined),
+    },
   })
+
+  if (res.status === 401) {
+    onUnauthorized?.()
+    throw new Error('Unauthorized')
+  }
+
   if (!res.ok) {
     const err = await res.json().catch(() => ({ error: res.statusText }))
     throw new Error((err as { error?: string }).error ?? res.statusText)

--- a/ui/src/lib/ws.ts
+++ b/ui/src/lib/ws.ts
@@ -1,3 +1,5 @@
+import { getToken } from '@/contexts/AuthContext'
+
 export type WsMessage = {
   event: string
   data: unknown
@@ -6,7 +8,12 @@ export type WsMessage = {
 
 export type WsListener = (msg: WsMessage) => void
 
-const WS_URL = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws`
+// Module-level callback invoked on 4401 close code (unauthorized)
+let onUnauthorized: (() => void) | null = null
+
+export function setWsUnauthorizedHandler(fn: () => void) {
+  onUnauthorized = fn
+}
 
 class WebSocketManager {
   private ws: WebSocket | null = null
@@ -17,12 +24,22 @@ class WebSocketManager {
 
   get status() { return this._status }
 
+  private _buildUrl(): string {
+    const base = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws`
+    const token = getToken()
+    return token ? `${base}?token=${encodeURIComponent(token)}` : base
+  }
+
   connect() {
     if (this.ws?.readyState === WebSocket.OPEN) return
     this._setStatus('connecting')
-    this.ws = new WebSocket(WS_URL)
+    this.ws = new WebSocket(this._buildUrl())
     this.ws.onopen = () => this._setStatus('connected')
-    this.ws.onclose = () => {
+    this.ws.onclose = (evt) => {
+      if (evt.code === 4401) {
+        onUnauthorized?.()
+        return
+      }
       this._setStatus('disconnected')
       this.reconnectTimer = setTimeout(() => this.connect(), 3000)
     }

--- a/ui/src/views/LoginView.tsx
+++ b/ui/src/views/LoginView.tsx
@@ -1,0 +1,93 @@
+import { useState, useEffect, FormEvent } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useAuth } from '@/contexts/AuthContext'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Checkbox } from '@/components/ui/checkbox'
+
+export default function LoginView() {
+  const { isAuthenticated, login } = useAuth()
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+
+  const [tokenValue, setTokenValue] = useState('')
+  const [remember, setRemember] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const rawRedirect = searchParams.get('redirect') ?? '/dashboard'
+  // Guard against open redirect: only allow same-origin relative paths
+  const redirect = rawRedirect.startsWith('/') && !rawRedirect.startsWith('//')
+    ? rawRedirect
+    : '/dashboard'
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      navigate(redirect, { replace: true })
+    }
+  }, [isAuthenticated, navigate, redirect])
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+    try {
+      await login(tokenValue, remember)
+      navigate(redirect, { replace: true })
+    } catch {
+      setError('Invalid token — check your agentforge.yml')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background p-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader className="space-y-1">
+          <CardTitle className="text-2xl">AgentForge</CardTitle>
+          <CardDescription>Enter your API secret to continue</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="token">API Secret</Label>
+              <Input
+                id="token"
+                type="password"
+                placeholder="••••••••"
+                value={tokenValue}
+                onChange={(e) => setTokenValue(e.target.value)}
+                disabled={loading}
+                autoFocus
+                autoComplete="current-password"
+              />
+            </div>
+
+            {error && (
+              <p className="text-sm text-destructive">{error}</p>
+            )}
+
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="remember"
+                checked={remember}
+                onCheckedChange={setRemember}
+                disabled={loading}
+              />
+              <Label htmlFor="remember" className="font-normal cursor-pointer">
+                Remember me
+              </Label>
+            </div>
+
+            <Button type="submit" className="w-full" disabled={loading || !tokenValue}>
+              {loading ? 'Verifying…' : 'Sign in'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds `tests/execution/inter-agent-comm.test.js` with 14 tests for `src/execution/inter-agent-comm.js`
- Tests `getToolDefinition()` schema (name, required fields, priority enum)
- Tests `pendingCount()` lifecycle: 0 initially, 1 while in-flight, back to 0 after resolve/reject
- Tests `ask()`: task creation with correct fields and defaults, resolves with `task.result`, resolves with `""` when result is undefined, rejects on `task.failed`, ignores events for unrelated task IDs
- Long timers are `unref()`'d to allow clean process exit

## Test plan
- [ ] `node --test tests/execution/inter-agent-comm.test.js` — 14 tests pass

https://claude.ai/code/session_0145JmbX6SnndfRd92nirCeX