### PR TITLE
test(execution): add review-workflow.js unit tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,7 +41,7 @@ jobs:
         run: npx playwright test --config e2e/playwright.config.ts --project chromium
 
       - name: Upload test report
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b  # v4.3.6
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v4.3.6
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
              agentforge-v${{ steps.version.outputs.VERSION }}.tgz
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2
         with:
           generate_release_notes: true
           files: agentforge-v${{ steps.version.outputs.VERSION }}.tgz

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -27,7 +27,7 @@ jobs:
           results_format: sarif
           publish_results: true
       - name: Upload SARIF results to Security tab
-        uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e  # v4.32.4
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4.34.1
         with:
           sarif_file: results.sarif
           category: scorecard

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -40,10 +40,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@89a39a4e59826350b863aa6b6252a07ad50cf83e  # v4.32.4
+        uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4.34.1
         with:
           languages: javascript
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@89a39a4e59826350b863aa6b6252a07ad50cf83e  # v4.32.4
+        uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4.34.1
         with:
           category: '/language:javascript'

--- a/agentforge.example.yml
+++ b/agentforge.example.yml
@@ -220,3 +220,6 @@ alerts:
 server:
   port: 4242
   host: localhost
+  auth:
+    enabled: false          # Set to true + provide secret for production
+    secret: ${AGENTFORGE_SECRET}

--- a/e2e/tests/login.spec.ts
+++ b/e2e/tests/login.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from './fixtures'
+
+/**
+ * Login UI — auth bypass tests.
+ *
+ * The E2E server runs with auth disabled (default config), so:
+ * - /api/status returns 200 without a token
+ * - The AuthProvider auto-authenticates and skips the login page
+ * - All views remain accessible without any token in storage
+ */
+
+test.describe('Login — auth bypass when auth is disabled', () => {
+  test('login page redirects to dashboard when auth is disabled', async ({ page }) => {
+    await page.goto('/login')
+    // With auth disabled, AuthProvider sets isAuthenticated = true automatically,
+    // so LoginView redirects to /dashboard.
+    await expect(page).toHaveURL(/\/dashboard/, { timeout: 5000 })
+  })
+
+  test('navigating to / redirects to /dashboard without login', async ({ page }) => {
+    await page.goto('/')
+    await expect(page).toHaveURL(/\/dashboard/)
+  })
+
+  test('dashboard is accessible without a token when auth disabled', async ({ page }) => {
+    await page.goto('/dashboard')
+    await expect(page.getByRole('link', { name: 'Dashboard' })).toBeVisible()
+    await expect(page.locator('body')).not.toContainText('Something went wrong')
+  })
+
+  test('kanban is accessible without a token when auth disabled', async ({ page }) => {
+    await page.goto('/kanban')
+    await expect(page.getByRole('link', { name: 'Kanban' })).toBeVisible()
+    await expect(page.locator('body')).not.toContainText('Something went wrong')
+  })
+
+  test('agents is accessible without a token when auth disabled', async ({ page }) => {
+    await page.goto('/agents')
+    await expect(page.getByRole('link', { name: 'Agents' })).toBeVisible()
+    await expect(page.locator('body')).not.toContainText('Something went wrong')
+  })
+
+  test('providers is accessible without a token when auth disabled', async ({ page }) => {
+    await page.goto('/providers')
+    await expect(page.getByRole('link', { name: 'Providers' })).toBeVisible()
+    await expect(page.locator('body')).not.toContainText('Something went wrong')
+  })
+
+  test('costs is accessible without a token when auth disabled', async ({ page }) => {
+    await page.goto('/costs')
+    await page.waitForLoadState('networkidle')
+    const content = page.getByText('Total Spend').or(page.getByText('Cost tracking not available.'))
+    await expect(content.first()).toBeVisible()
+    await expect(page.locator('body')).not.toContainText('Something went wrong')
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -2116,9 +2116,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -16,6 +16,7 @@ import express from 'express';
 import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
 import { startWebSocketServer } from './ws.js';
+import { createAuthMiddleware } from '../auth/auth.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -507,6 +508,9 @@ export function startServer(forge, port = 3000, host = '127.0.0.1') {
   // CORS — must be before routes
   app.use(corsMiddleware);
 
+  // Auth — must be before rate limiters and router
+  app.use('/api', createAuthMiddleware(forge.config?.server?.auth ?? {}));
+
   // Rate limiting — scoped to API routes only (not static files)
   app.use('/api', generalLimiter);
   app.post('/api/*splat', mutationLimiter);
@@ -528,7 +532,11 @@ export function startServer(forge, port = 3000, host = '127.0.0.1') {
 
   // Create the HTTP server and attach the WebSocket server
   const httpServer = http.createServer(app);
-  startWebSocketServer(httpServer, forge.eventBus);
+  startWebSocketServer(httpServer, forge.eventBus, forge.config?.server?.auth ?? {});
+
+  if (!forge.config?.server?.auth?.enabled) {
+    console.warn('[agentforge:api] WARNING: API auth is disabled — set server.auth.secret in agentforge.yml for production use');
+  }
 
   httpServer.listen(port, host, () => {
     console.log('[agentforge:api] REST API listening on http://%s:%d', host, port);

--- a/src/api/ws.js
+++ b/src/api/ws.js
@@ -10,6 +10,7 @@
  */
 
 import { WebSocketServer } from 'ws';
+import { timingSafeEqual } from 'node:crypto';
 
 // ---------------------------------------------------------------------------
 // Event list — all events that are broadcast to connected clients
@@ -59,6 +60,23 @@ function broadcast(wss, message) {
 }
 
 /**
+ * Constant-time token comparison to prevent timing side-channel attacks.
+ *
+ * @param {string} a
+ * @param {string} b
+ * @returns {boolean}
+ */
+function wsTokenEqual(a, b) {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) {
+    timingSafeEqual(bufA, bufA);
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
+}
+
+/**
  * Send a single message to a specific client, ignoring send errors
  * (the client may have disconnected between the readyState check and send).
  *
@@ -85,6 +103,10 @@ function sendToClient(ws, message) {
  * The WebSocket endpoint is mounted at `/ws` on the same port as the REST API.
  *
  * Behaviour per connection:
+ *  - When `authConfig.enabled` is true (and `NODE_ENV !== 'test'`), the
+ *    connecting client must supply the shared secret as a `?token=<secret>`
+ *    query parameter.  Connections without a valid token are closed with code
+ *    4401 and the message "Unauthorized".
  *  - Replays the last 20 events immediately on connect.
  *  - Forwards every listed event from the eventBus as it fires.
  *  - Sends a ping frame every 30 s; closes the connection if no pong is
@@ -93,6 +115,7 @@ function sendToClient(ws, message) {
  *
  * @param {import('http').Server} httpServer - The Node.js HTTP server to attach to.
  * @param {import('../core/event-bus.js').default} eventBus - The AgentForge event bus singleton.
+ * @param {{ enabled?: boolean, secret?: string }} [authConfig={}] - Auth config.
  * @returns {WebSocketServer} The created WebSocket server instance.
  *
  * @example
@@ -103,14 +126,23 @@ function sendToClient(ws, message) {
  *
  * const app = express();
  * const httpServer = http.createServer(app);
- * startWebSocketServer(httpServer, eventBus);
+ * startWebSocketServer(httpServer, eventBus, { enabled: false });
  * httpServer.listen(3000);
  */
-export function startWebSocketServer(httpServer, eventBus) {
+export function startWebSocketServer(httpServer, eventBus, authConfig = {}) {
   const wss = new WebSocketServer({ server: httpServer, path: '/ws' });
 
   // ── Per-connection logic ─────────────────────────────────────────────────
-  wss.on('connection', (ws) => {
+  wss.on('connection', (ws, req) => {
+    // Token auth check for WebSocket connections
+    if (authConfig.enabled && process.env.NODE_ENV !== 'test') {
+      const url = new URL(req.url, 'http://localhost');
+      const token = url.searchParams.get('token');
+      if (!token || !authConfig.secret || !wsTokenEqual(token, authConfig.secret)) {
+        ws.close(4401, 'Unauthorized');
+        return;
+      }
+    }
     // Replay the last 20 events so the dashboard can hydrate immediately
     const recent = eventBus.getRecentEvents(20);
     for (const entry of recent) {

--- a/src/auth/auth.js
+++ b/src/auth/auth.js
@@ -1,0 +1,86 @@
+/**
+ * @file src/auth/auth.js
+ * @description Static Bearer-token authentication middleware for AgentForge.
+ *
+ * GitHub issue #93
+ */
+
+import { timingSafeEqual } from 'node:crypto';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Constant-time string comparison using Node's crypto.timingSafeEqual to
+ * prevent timing side-channel attacks when comparing secrets.
+ *
+ * @param {string} a
+ * @param {string} b
+ * @returns {boolean}
+ */
+function safeEqual(a, b) {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) {
+    // Lengths differ — still run timingSafeEqual on equal-length buffers to
+    // avoid a length-based timing leak, then return false.
+    timingSafeEqual(bufA, bufA);
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Create an Express middleware that enforces Bearer-token authentication.
+ *
+ * Behaviour:
+ * - If `authConfig.enabled` is falsy → calls `next()` immediately (auth off).
+ * - If `NODE_ENV === 'test'` → calls `next()` immediately (test bypass).
+ * - Exempts `GET /api/status` so load-balancers can perform health checks
+ *   without a token.
+ * - Reads the `Authorization: Bearer <token>` header and compares it to
+ *   `authConfig.secret` using a constant-time comparison.
+ * - Returns `401 { ok: false, error: "Unauthorized" }` if the token is
+ *   missing or incorrect.
+ *
+ * @param {{ enabled?: boolean, secret?: string }} authConfig
+ * @returns {import('express').RequestHandler}
+ *
+ * @example
+ * import { createAuthMiddleware } from '../auth/auth.js';
+ * app.use('/api', createAuthMiddleware(forge.config?.server?.auth ?? {}));
+ */
+export function createAuthMiddleware(authConfig = {}) {
+  return function authMiddleware(req, res, next) {
+    // Bypass in test environment
+    if (process.env.NODE_ENV === 'test') {
+      return next();
+    }
+
+    // Bypass when auth is disabled
+    if (!authConfig.enabled) {
+      return next();
+    }
+
+    // Health-check exemption — always allow GET /api/status
+    if (req.method === 'GET' && req.path === '/status') {
+      return next();
+    }
+
+    // Extract Bearer token from Authorization header
+    const authHeader = req.headers['authorization'] ?? '';
+    const match = /^Bearer\s+(\S+)$/i.exec(authHeader);
+    const token = match ? match[1] : null;
+
+    if (!token || !authConfig.secret || !safeEqual(token, authConfig.secret)) {
+      return res.status(401).json({ ok: false, error: 'Unauthorized' });
+    }
+
+    return next();
+  };
+}

--- a/tests/api/auth.test.js
+++ b/tests/api/auth.test.js
@@ -1,0 +1,169 @@
+/**
+ * @file tests/api/auth.test.js
+ * @description Unit tests for src/auth/auth.js createAuthMiddleware.
+ *
+ * GitHub issue #93
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createAuthMiddleware } from '../../src/auth/auth.js';
+
+// ---------------------------------------------------------------------------
+// Helpers — minimal req/res/next stubs
+// ---------------------------------------------------------------------------
+
+function makeReq({ method = 'GET', path = '/tasks', authorization } = {}) {
+  return {
+    method,
+    path,
+    headers: authorization ? { authorization } : {},
+  };
+}
+
+function makeRes() {
+  const res = {
+    _status: null,
+    _body: null,
+    status(code) {
+      this._status = code;
+      return this;
+    },
+    json(body) {
+      this._body = body;
+      return this;
+    },
+  };
+  return res;
+}
+
+function makeNext() {
+  let called = false;
+  const fn = () => { called = true; };
+  fn.wasCalled = () => called;
+  return fn;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createAuthMiddleware', () => {
+  const SECRET = 'test-secret-abc123';
+
+  // Save and restore NODE_ENV around tests that mutate it
+  let savedNodeEnv;
+  beforeEach(() => { savedNodeEnv = process.env.NODE_ENV; });
+  afterEach(() => { process.env.NODE_ENV = savedNodeEnv; });
+
+  // ── auth disabled ────────────────────────────────────────────────────────
+
+  it('calls next() immediately when enabled=false', () => {
+    const mw = createAuthMiddleware({ enabled: false, secret: SECRET });
+    const req = makeReq({ authorization: undefined });
+    const res = makeRes();
+    const next = makeNext();
+
+    process.env.NODE_ENV = 'production'; // ensure not in test bypass
+    mw(req, res, next);
+
+    assert.ok(next.wasCalled(), 'next should be called');
+    assert.equal(res._status, null, 'should not set status');
+  });
+
+  it('calls next() when authConfig is empty object (enabled falsy)', () => {
+    const mw = createAuthMiddleware({});
+    const next = makeNext();
+    process.env.NODE_ENV = 'production';
+    mw(makeReq(), makeRes(), next);
+    assert.ok(next.wasCalled());
+  });
+
+  // ── NODE_ENV=test bypass ─────────────────────────────────────────────────
+
+  it('calls next() in test environment regardless of enabled=true', () => {
+    process.env.NODE_ENV = 'test';
+    const mw = createAuthMiddleware({ enabled: true, secret: SECRET });
+    const next = makeNext();
+    // No Authorization header — should still pass
+    mw(makeReq(), makeRes(), next);
+    assert.ok(next.wasCalled());
+  });
+
+  it('calls next() in test environment with wrong token', () => {
+    process.env.NODE_ENV = 'test';
+    const mw = createAuthMiddleware({ enabled: true, secret: SECRET });
+    const next = makeNext();
+    mw(makeReq({ authorization: 'Bearer wrong-token' }), makeRes(), next);
+    assert.ok(next.wasCalled());
+  });
+
+  // ── auth enabled, correct token ──────────────────────────────────────────
+
+  it('calls next() when enabled=true and correct Bearer token is provided', () => {
+    process.env.NODE_ENV = 'production';
+    const mw = createAuthMiddleware({ enabled: true, secret: SECRET });
+    const next = makeNext();
+    mw(makeReq({ authorization: `Bearer ${SECRET}` }), makeRes(), next);
+    assert.ok(next.wasCalled());
+  });
+
+  // ── auth enabled, wrong token ────────────────────────────────────────────
+
+  it('returns 401 when enabled=true and wrong token is provided', () => {
+    process.env.NODE_ENV = 'production';
+    const mw = createAuthMiddleware({ enabled: true, secret: SECRET });
+    const res = makeRes();
+    const next = makeNext();
+    mw(makeReq({ authorization: 'Bearer wrong-token' }), res, next);
+    assert.equal(res._status, 401);
+    assert.deepEqual(res._body, { ok: false, error: 'Unauthorized' });
+    assert.ok(!next.wasCalled());
+  });
+
+  // ── auth enabled, no Authorization header ────────────────────────────────
+
+  it('returns 401 when enabled=true and no Authorization header', () => {
+    process.env.NODE_ENV = 'production';
+    const mw = createAuthMiddleware({ enabled: true, secret: SECRET });
+    const res = makeRes();
+    const next = makeNext();
+    mw(makeReq(), res, next);
+    assert.equal(res._status, 401);
+    assert.deepEqual(res._body, { ok: false, error: 'Unauthorized' });
+    assert.ok(!next.wasCalled());
+  });
+
+  it('returns 401 when Authorization header has wrong scheme', () => {
+    process.env.NODE_ENV = 'production';
+    const mw = createAuthMiddleware({ enabled: true, secret: SECRET });
+    const res = makeRes();
+    const next = makeNext();
+    mw(makeReq({ authorization: `Basic ${SECRET}` }), res, next);
+    assert.equal(res._status, 401);
+    assert.ok(!next.wasCalled());
+  });
+
+  // ── health-check exemption ───────────────────────────────────────────────
+
+  it('passes GET /api/status through even when enabled=true and no token', () => {
+    process.env.NODE_ENV = 'production';
+    // The middleware is mounted at /api, so req.path is /status (not /api/status)
+    const mw = createAuthMiddleware({ enabled: true, secret: SECRET });
+    const next = makeNext();
+    const req = makeReq({ method: 'GET', path: '/status' });
+    mw(req, makeRes(), next);
+    assert.ok(next.wasCalled());
+  });
+
+  it('does NOT exempt POST /api/status from auth', () => {
+    process.env.NODE_ENV = 'production';
+    const mw = createAuthMiddleware({ enabled: true, secret: SECRET });
+    const res = makeRes();
+    const next = makeNext();
+    const req = makeReq({ method: 'POST', path: '/status' });
+    mw(req, res, next);
+    assert.equal(res._status, 401);
+    assert.ok(!next.wasCalled());
+  });
+});

--- a/tests/execution/review-workflow.test.js
+++ b/tests/execution/review-workflow.test.js
@@ -1,164 +1,240 @@
-import { describe, it, beforeEach } from 'node:test';
-import assert from 'node:assert/strict';
-import { ReviewWorkflow } from '../../src/execution/review-workflow.js';
-import eventBus from '../../src/core/event-bus.js';
+/**
+ * @file tests/execution/review-workflow.test.js
+ * @description Unit tests for src/execution/review-workflow.js
+ *
+ * Covers:
+ *  - needsReview(): false when agent missing, no require_review, no reviewer;
+ *    true when both require_review and reviewer are set
+ *  - _buildReviewPrompt(): contains task title, type, model, result; truncates long results
+ *  - submitForReview(): early return when no reviewer, emits review.submitted,
+ *    calls interAgentComm.ask(), interprets "APPROVE"/"REJECT" in feedback,
+ *    emits review.completed, handles errors gracefully
+ */
 
-describe('ReviewWorkflow', () => {
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import eventBus from '../../src/core/event-bus.js';
+import { ReviewWorkflow } from '../../src/execution/review-workflow.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTask(overrides = {}) {
+  return {
+    id: 'task-1',
+    title: 'Implement feature X',
+    type: 'implement',
+    model_used: 'claude-opus-4-6',
+    agent_id: 'developer',
+    result: 'Here is the implementation.',
+    ...overrides,
+  };
+}
+
+function makeComm(feedbackOrError) {
+  return {
+    async ask(_fromAgent, _toAgent, _prompt, _opts) {
+      if (feedbackOrError instanceof Error) throw feedbackOrError;
+      return feedbackOrError;
+    },
+  };
+}
+
+const agents = {
+  developer: { require_review: true, reviewer: 'reviewer' },
+  unreviewed: { require_review: false },
+  'no-reviewer': { require_review: true }, // reviewer not set
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ReviewWorkflow.needsReview()', () => {
   let workflow;
-  let mockTaskQueue;
-  let mockComm;
-  let agents;
 
   beforeEach(() => {
-    mockTaskQueue = {};
-    mockComm = {
-      calls: [],
-      async ask(fromId, toId, question, opts) {
-        this.calls.push({ fromId, toId, question, opts });
-        return this._response || 'APPROVE looks good';
-      },
-    };
-    agents = {
-      'developer': { require_review: true, reviewer: 'reviewer' },
-      'reviewer': { require_review: false, reviewer: null },
-      'solo': { require_review: false },
-    };
-    workflow = new ReviewWorkflow({ taskQueue: mockTaskQueue, interAgentComm: mockComm, agents });
-  });
-
-  describe('needsReview()', () => {
-    it('returns true when agent has require_review and reviewer', () => {
-      const task = { agent_id: 'developer' };
-      assert.equal(workflow.needsReview(task), true);
-    });
-
-    it('returns false when agent has require_review but no reviewer', () => {
-      agents['dev2'] = { require_review: true, reviewer: null };
-      assert.equal(workflow.needsReview({ agent_id: 'dev2' }), false);
-    });
-
-    it('returns false when require_review is false', () => {
-      assert.equal(workflow.needsReview({ agent_id: 'solo' }), false);
-    });
-
-    it('returns false when agent is not in agents map', () => {
-      assert.equal(workflow.needsReview({ agent_id: 'unknown' }), false);
-    });
-
-    it('returns false when task has no agent_id', () => {
-      assert.equal(workflow.needsReview({}), false);
+    workflow = new ReviewWorkflow({
+      taskQueue: {},
+      interAgentComm: makeComm('APPROVE'),
+      agents,
     });
   });
 
-  describe('submitForReview()', () => {
-    it('returns approved:true when response does not include "reject"', async () => {
-      mockComm._response = 'APPROVE everything looks good';
-      const task = { id: 't1', agent_id: 'developer', title: 'Task 1', type: 'implement', model_used: 'claude', result: 'result text' };
-      const result = await workflow.submitForReview(task);
-      assert.equal(result.approved, true);
-      assert.equal(result.feedback, 'APPROVE everything looks good');
-    });
-
-    it('returns approved:false when response includes "reject"', async () => {
-      mockComm._response = 'REJECT the code has issues';
-      const task = { id: 't2', agent_id: 'developer', title: 'Task 2', type: 'implement', model_used: 'claude', result: 'bad result' };
-      const result = await workflow.submitForReview(task);
-      assert.equal(result.approved, false);
-    });
-
-    it('is case-insensitive when checking for reject', async () => {
-      mockComm._response = 'I must REJECT this submission';
-      const task = { id: 't3', agent_id: 'developer', title: 'T', type: 'test', model_used: 'claude', result: 'x' };
-      const result = await workflow.submitForReview(task);
-      assert.equal(result.approved, false);
-    });
-
-    it('calls interAgentComm.ask with reviewer as target', async () => {
-      const task = { id: 't4', agent_id: 'developer', title: 'Fix bug', type: 'implement', model_used: 'claude', result: 'done' };
-      await workflow.submitForReview(task);
-      assert.equal(mockComm.calls.length, 1);
-      assert.equal(mockComm.calls[0].fromId, 'developer');
-      assert.equal(mockComm.calls[0].toId, 'reviewer');
-      assert.equal(mockComm.calls[0].opts.type, 'review');
-      assert.equal(mockComm.calls[0].opts.priority, 'high');
-    });
-
-    it('returns approved:true and skips comm when no reviewer configured', async () => {
-      const task = { id: 't5', agent_id: 'solo', title: 'T', type: 'test', model_used: 'claude', result: '' };
-      const result = await workflow.submitForReview(task);
-      assert.equal(result.approved, true);
-      assert.equal(mockComm.calls.length, 0);
-    });
-
-    it('returns approved:false when comm.ask throws', async () => {
-      mockComm.ask = async () => { throw new Error('timeout'); };
-      const task = { id: 't6', agent_id: 'developer', title: 'T', type: 'test', model_used: 'claude', result: '' };
-      const result = await workflow.submitForReview(task);
-      assert.equal(result.approved, false);
-      assert.match(result.feedback, /timeout/);
-    });
-
-    it('emits review.submitted event', async () => {
-      let submittedEvent = null;
-      eventBus.once('review.submitted', (event) => {
-        submittedEvent = event;
-      });
-
-      const task = { id: 't7', agent_id: 'developer', title: 'T', type: 'test', model_used: 'claude', result: '' };
-      await workflow.submitForReview(task);
-
-      assert.ok(submittedEvent, 'review.submitted event was not emitted');
-      assert.equal(submittedEvent.task_id, 't7');
-      assert.equal(submittedEvent.reviewer, 'reviewer');
-    });
-
-    it('emits review.completed event with approved status', async () => {
-      let completedEvent = null;
-      eventBus.once('review.completed', (event) => {
-        completedEvent = event;
-      });
-
-      mockComm._response = 'APPROVE';
-      const task = { id: 't8', agent_id: 'developer', title: 'T', type: 'test', model_used: 'claude', result: '' };
-      await workflow.submitForReview(task);
-
-      assert.ok(completedEvent, 'review.completed event was not emitted');
-      assert.equal(completedEvent.task_id, 't8');
-      assert.equal(completedEvent.approved, true);
-    });
+  it('returns false for an unknown agent_id', () => {
+    assert.equal(workflow.needsReview(makeTask({ agent_id: 'unknown-agent' })), false);
   });
 
-  describe('_buildReviewPrompt()', () => {
-    it('includes task title, type, model, and result', () => {
-      const task = { id: 'x', title: 'My Task', type: 'implement', model_used: 'claude-opus', result: 'The output' };
-      const prompt = workflow._buildReviewPrompt(task);
-      assert.ok(prompt.includes('My Task'));
-      assert.ok(prompt.includes('implement'));
-      assert.ok(prompt.includes('claude-opus'));
-      assert.ok(prompt.includes('The output'));
+  it('returns false when agent has require_review: false', () => {
+    assert.equal(workflow.needsReview(makeTask({ agent_id: 'unreviewed' })), false);
+  });
+
+  it('returns false when agent has require_review but no reviewer', () => {
+    assert.equal(workflow.needsReview(makeTask({ agent_id: 'no-reviewer' })), false);
+  });
+
+  it('returns true when agent has both require_review: true and a reviewer', () => {
+    assert.equal(workflow.needsReview(makeTask({ agent_id: 'developer' })), true);
+  });
+});
+
+describe('ReviewWorkflow._buildReviewPrompt()', () => {
+  let workflow;
+
+  beforeEach(() => {
+    workflow = new ReviewWorkflow({ taskQueue: {}, interAgentComm: makeComm(''), agents });
+  });
+
+  it('includes task title, type, and model_used', () => {
+    const task = makeTask();
+    const prompt = workflow._buildReviewPrompt(task);
+    assert.ok(prompt.includes('Implement feature X'), 'title missing');
+    assert.ok(prompt.includes('implement'), 'type missing');
+    assert.ok(prompt.includes('claude-opus-4-6'), 'model missing');
+  });
+
+  it('includes APPROVE or REJECT instruction', () => {
+    const prompt = workflow._buildReviewPrompt(makeTask());
+    assert.ok(prompt.includes('APPROVE') || prompt.includes('REJECT'), 'instruction missing');
+  });
+
+  it('includes the task result', () => {
+    const task = makeTask({ result: 'My wonderful output' });
+    const prompt = workflow._buildReviewPrompt(task);
+    assert.ok(prompt.includes('My wonderful output'));
+  });
+
+  it('truncates result to 2000 characters', () => {
+    const longResult = 'x'.repeat(5000);
+    const task = makeTask({ result: longResult });
+    const prompt = workflow._buildReviewPrompt(task);
+    // The result in the prompt should be at most 2000 chars
+    assert.ok(!prompt.includes(longResult), 'full long result should not appear');
+    assert.ok(prompt.includes('x'.repeat(2000)), 'truncated result should appear');
+  });
+
+  it('uses "(no result)" when result is empty', () => {
+    const task = makeTask({ result: '' });
+    const prompt = workflow._buildReviewPrompt(task);
+    assert.ok(prompt.includes('(no result)'));
+  });
+
+  it('uses "(no result)" when result is undefined', () => {
+    const task = makeTask({ result: undefined });
+    const prompt = workflow._buildReviewPrompt(task);
+    assert.ok(prompt.includes('(no result)'));
+  });
+});
+
+describe('ReviewWorkflow.submitForReview()', () => {
+  let capturedEvents;
+
+  beforeEach(() => {
+    capturedEvents = [];
+    eventBus._log = [];
+    eventBus.on('review.submitted', (d) => capturedEvents.push({ event: 'review.submitted', data: d }));
+    eventBus.on('review.completed', (d) => capturedEvents.push({ event: 'review.completed', data: d }));
+  });
+
+  afterEach(() => {
+    eventBus.removeAllListeners('review.submitted');
+    eventBus.removeAllListeners('review.completed');
+  });
+
+  it('returns approved:true without calling comm when agent has no reviewer', async () => {
+    let askCalled = false;
+    const comm = { async ask() { askCalled = true; return 'should not be called'; } };
+    const workflow = new ReviewWorkflow({
+      taskQueue: {},
+      interAgentComm: comm,
+      agents: { developer: { require_review: true } }, // no reviewer
     });
 
-    it('falls back to "(no result)" when result is absent', () => {
-      const task = { id: 'x', title: 'T', type: 'test', model_used: 'claude' };
-      const prompt = workflow._buildReviewPrompt(task);
-      assert.ok(prompt.includes('(no result)'));
-    });
+    const result = await workflow.submitForReview(makeTask({ agent_id: 'developer' }));
+    assert.equal(result.approved, true);
+    assert.equal(askCalled, false, 'ask() should not be called');
+  });
 
-    it('truncates result to 2000 characters', () => {
-      const longResult = 'x'.repeat(5000);
-      const task = { id: 'x', title: 'T', type: 'test', model_used: 'claude', result: longResult };
-      const prompt = workflow._buildReviewPrompt(task);
-      // The truncated result in the prompt should include exactly the first 2000 characters of the result
-      const first2000 = longResult.slice(0, 2000);
-      const rest = longResult.slice(2000);
-      assert.ok(prompt.includes(first2000));
-      assert.ok(!prompt.includes(rest));
+  it('emits review.submitted with task_id and reviewer before asking', async () => {
+    const workflow = new ReviewWorkflow({
+      taskQueue: {},
+      interAgentComm: makeComm('APPROVE — looks good'),
+      agents,
     });
+    await workflow.submitForReview(makeTask({ agent_id: 'developer' }));
+    const submitted = capturedEvents.find((e) => e.event === 'review.submitted');
+    assert.ok(submitted, 'review.submitted not emitted');
+    assert.equal(submitted.data.task_id, 'task-1');
+    assert.equal(submitted.data.reviewer, 'reviewer');
+  });
 
-    it('instructs reviewer to reply APPROVE or REJECT', () => {
-      const task = { id: 'x', title: 'T', type: 'test', model_used: 'claude', result: 'r' };
-      const prompt = workflow._buildReviewPrompt(task);
-      assert.ok(prompt.includes('APPROVE') && prompt.includes('REJECT'));
+  it('returns approved:true when feedback does not contain "reject"', async () => {
+    const workflow = new ReviewWorkflow({
+      taskQueue: {},
+      interAgentComm: makeComm('APPROVE — looks great!'),
+      agents,
     });
+    const result = await workflow.submitForReview(makeTask({ agent_id: 'developer' }));
+    assert.equal(result.approved, true);
+    assert.equal(result.feedback, 'APPROVE — looks great!');
+  });
+
+  it('returns approved:false when feedback contains "reject" (case-insensitive)', async () => {
+    const workflow = new ReviewWorkflow({
+      taskQueue: {},
+      interAgentComm: makeComm('REJECT — needs more work'),
+      agents,
+    });
+    const result = await workflow.submitForReview(makeTask({ agent_id: 'developer' }));
+    assert.equal(result.approved, false);
+  });
+
+  it('returns approved:false when feedback contains lowercase "reject"', async () => {
+    const workflow = new ReviewWorkflow({
+      taskQueue: {},
+      interAgentComm: makeComm('I must reject this implementation'),
+      agents,
+    });
+    const result = await workflow.submitForReview(makeTask({ agent_id: 'developer' }));
+    assert.equal(result.approved, false);
+  });
+
+  it('emits review.completed with task_id, reviewer, and approved fields', async () => {
+    const workflow = new ReviewWorkflow({
+      taskQueue: {},
+      interAgentComm: makeComm('APPROVE'),
+      agents,
+    });
+    await workflow.submitForReview(makeTask({ agent_id: 'developer' }));
+    const completed = capturedEvents.find((e) => e.event === 'review.completed');
+    assert.ok(completed, 'review.completed not emitted');
+    assert.equal(completed.data.task_id, 'task-1');
+    assert.equal(completed.data.reviewer, 'reviewer');
+    assert.equal(completed.data.approved, true);
+  });
+
+  it('returns approved:false and feedback with error message when comm.ask() throws', async () => {
+    const workflow = new ReviewWorkflow({
+      taskQueue: {},
+      interAgentComm: makeComm(new Error('Agent timeout')),
+      agents,
+    });
+    const result = await workflow.submitForReview(makeTask({ agent_id: 'developer' }));
+    assert.equal(result.approved, false);
+    assert.ok(result.feedback.includes('Agent timeout'), 'error message should be in feedback');
+  });
+
+  it('emits review.completed with approved:false when comm.ask() throws', async () => {
+    const workflow = new ReviewWorkflow({
+      taskQueue: {},
+      interAgentComm: makeComm(new Error('Comm error')),
+      agents,
+    });
+    await workflow.submitForReview(makeTask({ agent_id: 'developer' }));
+    const completed = capturedEvents.find((e) => e.event === 'review.completed');
+    assert.ok(completed);
+    assert.equal(completed.data.approved, false);
+    assert.equal(completed.data.error, 'Comm error');
   });
 });

--- a/tests/execution/review-workflow.test.js
+++ b/tests/execution/review-workflow.test.js
@@ -98,7 +98,7 @@ describe('ReviewWorkflow', () => {
       assert.match(result.feedback, /timeout/);
     });
 
-    it('emits review.submitted event', async (t) => {
+    it('emits review.submitted event', async () => {
       const eventPromise = new Promise(resolve => eventBus.once('review.submitted', resolve));
 
       const task = { id: 't7', agent_id: 'developer', title: 'T', type: 'test', model_used: 'claude', result: '' };
@@ -109,7 +109,7 @@ describe('ReviewWorkflow', () => {
       assert.equal(event.reviewer, 'reviewer');
     });
 
-    it('emits review.completed event with approved status', async (t) => {
+    it('emits review.completed event with approved status', async () => {
       const eventPromise = new Promise(resolve => eventBus.once('review.completed', resolve));
 
       mockComm._response = 'APPROVE';

--- a/tests/execution/review-workflow.test.js
+++ b/tests/execution/review-workflow.test.js
@@ -148,9 +148,11 @@ describe('ReviewWorkflow', () => {
       const longResult = 'x'.repeat(5000);
       const task = { id: 'x', title: 'T', type: 'test', model_used: 'claude', result: longResult };
       const prompt = workflow._buildReviewPrompt(task);
-      // The truncated result in the prompt should not contain more than 2000 x's
-      const xCount = (prompt.match(/x/g) || []).length;
-      assert.ok(xCount <= 2000);
+      // The truncated result in the prompt should include exactly the first 2000 characters of the result
+      const first2000 = longResult.slice(0, 2000);
+      const rest = longResult.slice(2000);
+      assert.ok(prompt.includes(first2000));
+      assert.ok(!prompt.includes(rest));
     });
 
     it('instructs reviewer to reply APPROVE or REJECT', () => {

--- a/tests/execution/review-workflow.test.js
+++ b/tests/execution/review-workflow.test.js
@@ -99,26 +99,32 @@ describe('ReviewWorkflow', () => {
     });
 
     it('emits review.submitted event', async () => {
-      const eventPromise = new Promise(resolve => eventBus.once('review.submitted', resolve));
+      let submittedEvent = null;
+      eventBus.once('review.submitted', (event) => {
+        submittedEvent = event;
+      });
 
       const task = { id: 't7', agent_id: 'developer', title: 'T', type: 'test', model_used: 'claude', result: '' };
       await workflow.submitForReview(task);
 
-      const event = await eventPromise;
-      assert.equal(event.task_id, 't7');
-      assert.equal(event.reviewer, 'reviewer');
+      assert.ok(submittedEvent, 'review.submitted event was not emitted');
+      assert.equal(submittedEvent.task_id, 't7');
+      assert.equal(submittedEvent.reviewer, 'reviewer');
     });
 
     it('emits review.completed event with approved status', async () => {
-      const eventPromise = new Promise(resolve => eventBus.once('review.completed', resolve));
+      let completedEvent = null;
+      eventBus.once('review.completed', (event) => {
+        completedEvent = event;
+      });
 
       mockComm._response = 'APPROVE';
       const task = { id: 't8', agent_id: 'developer', title: 'T', type: 'test', model_used: 'claude', result: '' };
       await workflow.submitForReview(task);
 
-      const event = await eventPromise;
-      assert.equal(event.task_id, 't8');
-      assert.equal(event.approved, true);
+      assert.ok(completedEvent, 'review.completed event was not emitted');
+      assert.equal(completedEvent.task_id, 't8');
+      assert.equal(completedEvent.approved, true);
     });
   });
 

--- a/tests/execution/review-workflow.test.js
+++ b/tests/execution/review-workflow.test.js
@@ -1,0 +1,162 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { ReviewWorkflow } from '../../src/execution/review-workflow.js';
+import eventBus from '../../src/core/event-bus.js';
+
+describe('ReviewWorkflow', () => {
+  let workflow;
+  let mockTaskQueue;
+  let mockComm;
+  let agents;
+
+  beforeEach(() => {
+    mockTaskQueue = {};
+    mockComm = {
+      calls: [],
+      async ask(fromId, toId, question, opts) {
+        this.calls.push({ fromId, toId, question, opts });
+        return this._response || 'APPROVE looks good';
+      },
+    };
+    agents = {
+      'developer': { require_review: true, reviewer: 'reviewer' },
+      'reviewer': { require_review: false, reviewer: null },
+      'solo': { require_review: false },
+    };
+    workflow = new ReviewWorkflow({ taskQueue: mockTaskQueue, interAgentComm: mockComm, agents });
+  });
+
+  describe('needsReview()', () => {
+    it('returns true when agent has require_review and reviewer', () => {
+      const task = { agent_id: 'developer' };
+      assert.equal(workflow.needsReview(task), true);
+    });
+
+    it('returns false when agent has require_review but no reviewer', () => {
+      agents['dev2'] = { require_review: true, reviewer: null };
+      assert.equal(workflow.needsReview({ agent_id: 'dev2' }), false);
+    });
+
+    it('returns false when require_review is false', () => {
+      assert.equal(workflow.needsReview({ agent_id: 'solo' }), false);
+    });
+
+    it('returns false when agent is not in agents map', () => {
+      assert.equal(workflow.needsReview({ agent_id: 'unknown' }), false);
+    });
+
+    it('returns false when task has no agent_id', () => {
+      assert.equal(workflow.needsReview({}), false);
+    });
+  });
+
+  describe('submitForReview()', () => {
+    it('returns approved:true when response does not include "reject"', async () => {
+      mockComm._response = 'APPROVE everything looks good';
+      const task = { id: 't1', agent_id: 'developer', title: 'Task 1', type: 'implement', model_used: 'claude', result: 'result text' };
+      const result = await workflow.submitForReview(task);
+      assert.equal(result.approved, true);
+      assert.equal(result.feedback, 'APPROVE everything looks good');
+    });
+
+    it('returns approved:false when response includes "reject"', async () => {
+      mockComm._response = 'REJECT the code has issues';
+      const task = { id: 't2', agent_id: 'developer', title: 'Task 2', type: 'implement', model_used: 'claude', result: 'bad result' };
+      const result = await workflow.submitForReview(task);
+      assert.equal(result.approved, false);
+    });
+
+    it('is case-insensitive when checking for reject', async () => {
+      mockComm._response = 'I must REJECT this submission';
+      const task = { id: 't3', agent_id: 'developer', title: 'T', type: 'test', model_used: 'claude', result: 'x' };
+      const result = await workflow.submitForReview(task);
+      assert.equal(result.approved, false);
+    });
+
+    it('calls interAgentComm.ask with reviewer as target', async () => {
+      const task = { id: 't4', agent_id: 'developer', title: 'Fix bug', type: 'implement', model_used: 'claude', result: 'done' };
+      await workflow.submitForReview(task);
+      assert.equal(mockComm.calls.length, 1);
+      assert.equal(mockComm.calls[0].fromId, 'developer');
+      assert.equal(mockComm.calls[0].toId, 'reviewer');
+      assert.equal(mockComm.calls[0].opts.type, 'review');
+      assert.equal(mockComm.calls[0].opts.priority, 'high');
+    });
+
+    it('returns approved:true and skips comm when no reviewer configured', async () => {
+      const task = { id: 't5', agent_id: 'solo', title: 'T', type: 'test', model_used: 'claude', result: '' };
+      const result = await workflow.submitForReview(task);
+      assert.equal(result.approved, true);
+      assert.equal(mockComm.calls.length, 0);
+    });
+
+    it('returns approved:false when comm.ask throws', async () => {
+      mockComm.ask = async () => { throw new Error('timeout'); };
+      const task = { id: 't6', agent_id: 'developer', title: 'T', type: 'test', model_used: 'claude', result: '' };
+      const result = await workflow.submitForReview(task);
+      assert.equal(result.approved, false);
+      assert.match(result.feedback, /timeout/);
+    });
+
+    it('emits review.submitted event', async () => {
+      const events = [];
+      eventBus.on('review.submitted', e => events.push(e));
+
+      const task = { id: 't7', agent_id: 'developer', title: 'T', type: 'test', model_used: 'claude', result: '' };
+      await workflow.submitForReview(task);
+
+      assert.equal(events.length, 1);
+      assert.equal(events[0].task_id, 't7');
+      assert.equal(events[0].reviewer, 'reviewer');
+
+      eventBus.removeAllListeners('review.submitted');
+    });
+
+    it('emits review.completed event with approved status', async () => {
+      const events = [];
+      eventBus.on('review.completed', e => events.push(e));
+
+      mockComm._response = 'APPROVE';
+      const task = { id: 't8', agent_id: 'developer', title: 'T', type: 'test', model_used: 'claude', result: '' };
+      await workflow.submitForReview(task);
+
+      assert.equal(events.length, 1);
+      assert.equal(events[0].task_id, 't8');
+      assert.equal(events[0].approved, true);
+
+      eventBus.removeAllListeners('review.completed');
+    });
+  });
+
+  describe('_buildReviewPrompt()', () => {
+    it('includes task title, type, model, and result', () => {
+      const task = { id: 'x', title: 'My Task', type: 'implement', model_used: 'claude-opus', result: 'The output' };
+      const prompt = workflow._buildReviewPrompt(task);
+      assert.ok(prompt.includes('My Task'));
+      assert.ok(prompt.includes('implement'));
+      assert.ok(prompt.includes('claude-opus'));
+      assert.ok(prompt.includes('The output'));
+    });
+
+    it('falls back to "(no result)" when result is absent', () => {
+      const task = { id: 'x', title: 'T', type: 'test', model_used: 'claude' };
+      const prompt = workflow._buildReviewPrompt(task);
+      assert.ok(prompt.includes('(no result)'));
+    });
+
+    it('truncates result to 2000 characters', () => {
+      const longResult = 'x'.repeat(5000);
+      const task = { id: 'x', title: 'T', type: 'test', model_used: 'claude', result: longResult };
+      const prompt = workflow._buildReviewPrompt(task);
+      // The truncated result in the prompt should not contain more than 2000 x's
+      const xCount = (prompt.match(/x/g) || []).length;
+      assert.ok(xCount <= 2000);
+    });
+
+    it('instructs reviewer to reply APPROVE or REJECT', () => {
+      const task = { id: 'x', title: 'T', type: 'test', model_used: 'claude', result: 'r' };
+      const prompt = workflow._buildReviewPrompt(task);
+      assert.ok(prompt.includes('APPROVE') || prompt.includes('REJECT'));
+    });
+  });
+});

--- a/tests/execution/review-workflow.test.js
+++ b/tests/execution/review-workflow.test.js
@@ -98,33 +98,27 @@ describe('ReviewWorkflow', () => {
       assert.match(result.feedback, /timeout/);
     });
 
-    it('emits review.submitted event', async () => {
-      const events = [];
-      eventBus.on('review.submitted', e => events.push(e));
+    it('emits review.submitted event', async (t) => {
+      const eventPromise = new Promise(resolve => eventBus.once('review.submitted', resolve));
 
       const task = { id: 't7', agent_id: 'developer', title: 'T', type: 'test', model_used: 'claude', result: '' };
       await workflow.submitForReview(task);
 
-      assert.equal(events.length, 1);
-      assert.equal(events[0].task_id, 't7');
-      assert.equal(events[0].reviewer, 'reviewer');
-
-      eventBus.removeAllListeners('review.submitted');
+      const event = await eventPromise;
+      assert.equal(event.task_id, 't7');
+      assert.equal(event.reviewer, 'reviewer');
     });
 
-    it('emits review.completed event with approved status', async () => {
-      const events = [];
-      eventBus.on('review.completed', e => events.push(e));
+    it('emits review.completed event with approved status', async (t) => {
+      const eventPromise = new Promise(resolve => eventBus.once('review.completed', resolve));
 
       mockComm._response = 'APPROVE';
       const task = { id: 't8', agent_id: 'developer', title: 'T', type: 'test', model_used: 'claude', result: '' };
       await workflow.submitForReview(task);
 
-      assert.equal(events.length, 1);
-      assert.equal(events[0].task_id, 't8');
-      assert.equal(events[0].approved, true);
-
-      eventBus.removeAllListeners('review.completed');
+      const event = await eventPromise;
+      assert.equal(event.task_id, 't8');
+      assert.equal(event.approved, true);
     });
   });
 

--- a/tests/execution/review-workflow.test.js
+++ b/tests/execution/review-workflow.test.js
@@ -158,7 +158,7 @@ describe('ReviewWorkflow', () => {
     it('instructs reviewer to reply APPROVE or REJECT', () => {
       const task = { id: 'x', title: 'T', type: 'test', model_used: 'claude', result: 'r' };
       const prompt = workflow._buildReviewPrompt(task);
-      assert.ok(prompt.includes('APPROVE') || prompt.includes('REJECT'));
+      assert.ok(prompt.includes('APPROVE') && prompt.includes('REJECT'));
     });
   });
 });

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1980,6 +1980,70 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.1.tgz",
@@ -3049,9 +3113,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,27 +1,44 @@
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Navigate, Outlet, useLocation } from 'react-router-dom'
 import { WebSocketProvider } from '@/contexts/WebSocketContext'
+import { AuthProvider, useAuth } from '@/contexts/AuthContext'
 import { Layout } from '@/components/layout/Layout'
 import DashboardView from '@/views/DashboardView'
 import KanbanView from '@/views/KanbanView'
 import AgentsView from '@/views/AgentsView'
 import ProvidersView from '@/views/ProvidersView'
 import CostsView from '@/views/CostsView'
+import LoginView from '@/views/LoginView'
+
+function ProtectedRoute() {
+  const { isAuthenticated } = useAuth()
+  const location = useLocation()
+  if (!isAuthenticated) {
+    const redirect = location.pathname + location.search
+    return <Navigate to={`/login?redirect=${encodeURIComponent(redirect)}`} replace />
+  }
+  return <Outlet />
+}
 
 export default function App() {
   return (
     <BrowserRouter>
-      <WebSocketProvider>
-        <Routes>
-          <Route element={<Layout />}>
-            <Route index element={<Navigate to="/dashboard" replace />} />
-            <Route path="/dashboard" element={<DashboardView />} />
-            <Route path="/kanban" element={<KanbanView />} />
-            <Route path="/agents" element={<AgentsView />} />
-            <Route path="/providers" element={<ProvidersView />} />
-            <Route path="/costs" element={<CostsView />} />
-          </Route>
-        </Routes>
-      </WebSocketProvider>
+      <AuthProvider>
+        <WebSocketProvider>
+          <Routes>
+            <Route path="/login" element={<LoginView />} />
+            <Route element={<ProtectedRoute />}>
+              <Route element={<Layout />}>
+                <Route index element={<Navigate to="/dashboard" replace />} />
+                <Route path="/dashboard" element={<DashboardView />} />
+                <Route path="/kanban" element={<KanbanView />} />
+                <Route path="/agents" element={<AgentsView />} />
+                <Route path="/providers" element={<ProvidersView />} />
+                <Route path="/costs" element={<CostsView />} />
+              </Route>
+            </Route>
+          </Routes>
+        </WebSocketProvider>
+      </AuthProvider>
     </BrowserRouter>
   )
 }

--- a/ui/src/components/ui/checkbox.tsx
+++ b/ui/src/components/ui/checkbox.tsx
@@ -1,0 +1,29 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export interface CheckboxProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  onCheckedChange?: (checked: boolean) => void
+}
+
+const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
+  ({ className, onCheckedChange, onChange, ...props }, ref) => {
+    return (
+      <input
+        type="checkbox"
+        className={cn(
+          "h-4 w-4 rounded border border-input bg-transparent shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        onChange={(e) => {
+          onChange?.(e)
+          onCheckedChange?.(e.target.checked)
+        }}
+        {...props}
+      />
+    )
+  }
+)
+Checkbox.displayName = "Checkbox"
+
+export { Checkbox }

--- a/ui/src/components/ui/input.tsx
+++ b/ui/src/components/ui/input.tsx
@@ -1,0 +1,23 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/ui/src/components/ui/label.tsx
+++ b/ui/src/components/ui/label.tsx
@@ -1,0 +1,19 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+const Label = React.forwardRef<
+  HTMLLabelElement,
+  React.LabelHTMLAttributes<HTMLLabelElement>
+>(({ className, ...props }, ref) => (
+  <label
+    ref={ref}
+    className={cn(
+      "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+      className
+    )}
+    {...props}
+  />
+))
+Label.displayName = "Label"
+
+export { Label }

--- a/ui/src/contexts/AuthContext.tsx
+++ b/ui/src/contexts/AuthContext.tsx
@@ -1,0 +1,140 @@
+import { createContext, useContext, useEffect, useState, useCallback } from 'react'
+import { setUnauthorizedHandler } from '@/lib/api'
+import { setWsUnauthorizedHandler } from '@/lib/ws'
+
+interface AuthContextValue {
+  token: string | null
+  isAuthenticated: boolean
+  login: (token: string, remember: boolean) => Promise<void>
+  logout: () => void
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  token: null,
+  isAuthenticated: false,
+  login: async () => {},
+  logout: () => {},
+})
+
+// Module-level token storage for use outside React tree (e.g. in api.ts)
+let _token: string | null = null
+
+export function getToken(): string | null {
+  return _token
+}
+
+function readStoredToken(): string | null {
+  return localStorage.getItem('agentforge_token') ?? sessionStorage.getItem('agentforge_token')
+}
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [token, setToken] = useState<string | null>(() => {
+    const stored = readStoredToken()
+    _token = stored
+    return stored
+  })
+  const [isAuthenticated, setIsAuthenticated] = useState(false)
+  const [checking, setChecking] = useState(true)
+
+  const logout = useCallback(() => {
+    _token = null
+    setToken(null)
+    setIsAuthenticated(false)
+    localStorage.removeItem('agentforge_token')
+    sessionStorage.removeItem('agentforge_token')
+    window.location.href = '/login'
+  }, [])
+
+  // Register the 401 handler so api.ts can call logout
+  useEffect(() => {
+    setUnauthorizedHandler(logout)
+    setWsUnauthorizedHandler(logout)
+  }, [logout])
+
+  // On mount: check if auth is even required (auth_enabled bypass),
+  // or restore token from storage.
+  useEffect(() => {
+    async function checkAuth() {
+      try {
+        const res = await fetch('/api/status')
+        if (res.ok) {
+          const data = await res.json() as { auth_enabled?: boolean }
+          if (data.auth_enabled === false || !Object.prototype.hasOwnProperty.call(data, 'auth_enabled')) {
+            // Auth disabled or status returned 200 without a token — bypass login
+            // Keep any stored token in _token (or leave null); no auth header needed
+            _token = token
+            setIsAuthenticated(true)
+            setChecking(false)
+            return
+          }
+        }
+      } catch {
+        // Network error — fall through to token-based check
+      }
+
+      // Auth is enabled; check stored token
+      if (token) {
+        try {
+          const res = await fetch('/api/status', {
+            headers: { Authorization: `Bearer ${token}` },
+          })
+          if (res.ok) {
+            _token = token
+            setIsAuthenticated(true)
+          } else {
+            // Stored token is no longer valid
+            _token = null
+            setToken(null)
+            setIsAuthenticated(false)
+            localStorage.removeItem('agentforge_token')
+            sessionStorage.removeItem('agentforge_token')
+          }
+        } catch {
+          // Network error — keep token, assume authenticated for now
+          _token = token
+          setIsAuthenticated(true)
+        }
+      }
+      setChecking(false)
+    }
+
+    void checkAuth()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const login = useCallback(async (newToken: string, remember: boolean) => {
+    const res = await fetch('/api/status', {
+      headers: newToken ? { Authorization: `Bearer ${newToken}` } : {},
+    })
+    if (!res.ok) {
+      throw new Error('Invalid token')
+    }
+    _token = newToken
+    setToken(newToken)
+    setIsAuthenticated(true)
+    if (remember) {
+      localStorage.setItem('agentforge_token', newToken)
+    } else {
+      sessionStorage.setItem('agentforge_token', newToken)
+    }
+  }, [])
+
+  // While we're checking auth state, render a minimal spinner (avoids flash of login page)
+  if (checking) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background">
+        <div className="h-8 w-8 rounded-full border-2 border-muted border-t-foreground animate-spin" />
+      </div>
+    )
+  }
+
+  return (
+    <AuthContext.Provider value={{ token, isAuthenticated, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  return useContext(AuthContext)
+}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1,10 +1,34 @@
+import { getToken } from '@/contexts/AuthContext'
+
 const BASE = '/api'
 
+// Module-level callback invoked when a 401 response is received
+let onUnauthorized: (() => void) | null = null
+
+export function setUnauthorizedHandler(fn: () => void) {
+  onUnauthorized = fn
+}
+
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
+  const token = getToken()
+  const authHeaders: Record<string, string> = token
+    ? { Authorization: `Bearer ${token}` }
+    : {}
+
   const res = await fetch(`${BASE}${path}`, {
-    headers: { 'Content-Type': 'application/json' },
     ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeaders,
+      ...(options?.headers as Record<string, string> | undefined),
+    },
   })
+
+  if (res.status === 401) {
+    onUnauthorized?.()
+    throw new Error('Unauthorized')
+  }
+
   if (!res.ok) {
     const err = await res.json().catch(() => ({ error: res.statusText }))
     throw new Error((err as { error?: string }).error ?? res.statusText)

--- a/ui/src/lib/ws.ts
+++ b/ui/src/lib/ws.ts
@@ -1,3 +1,5 @@
+import { getToken } from '@/contexts/AuthContext'
+
 export type WsMessage = {
   event: string
   data: unknown
@@ -6,7 +8,12 @@ export type WsMessage = {
 
 export type WsListener = (msg: WsMessage) => void
 
-const WS_URL = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws`
+// Module-level callback invoked on 4401 close code (unauthorized)
+let onUnauthorized: (() => void) | null = null
+
+export function setWsUnauthorizedHandler(fn: () => void) {
+  onUnauthorized = fn
+}
 
 class WebSocketManager {
   private ws: WebSocket | null = null
@@ -17,12 +24,22 @@ class WebSocketManager {
 
   get status() { return this._status }
 
+  private _buildUrl(): string {
+    const base = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws`
+    const token = getToken()
+    return token ? `${base}?token=${encodeURIComponent(token)}` : base
+  }
+
   connect() {
     if (this.ws?.readyState === WebSocket.OPEN) return
     this._setStatus('connecting')
-    this.ws = new WebSocket(WS_URL)
+    this.ws = new WebSocket(this._buildUrl())
     this.ws.onopen = () => this._setStatus('connected')
-    this.ws.onclose = () => {
+    this.ws.onclose = (evt) => {
+      if (evt.code === 4401) {
+        onUnauthorized?.()
+        return
+      }
       this._setStatus('disconnected')
       this.reconnectTimer = setTimeout(() => this.connect(), 3000)
     }

--- a/ui/src/views/LoginView.tsx
+++ b/ui/src/views/LoginView.tsx
@@ -1,0 +1,93 @@
+import { useState, useEffect, FormEvent } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useAuth } from '@/contexts/AuthContext'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Checkbox } from '@/components/ui/checkbox'
+
+export default function LoginView() {
+  const { isAuthenticated, login } = useAuth()
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+
+  const [tokenValue, setTokenValue] = useState('')
+  const [remember, setRemember] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const rawRedirect = searchParams.get('redirect') ?? '/dashboard'
+  // Guard against open redirect: only allow same-origin relative paths
+  const redirect = rawRedirect.startsWith('/') && !rawRedirect.startsWith('//')
+    ? rawRedirect
+    : '/dashboard'
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      navigate(redirect, { replace: true })
+    }
+  }, [isAuthenticated, navigate, redirect])
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+    try {
+      await login(tokenValue, remember)
+      navigate(redirect, { replace: true })
+    } catch {
+      setError('Invalid token — check your agentforge.yml')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background p-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader className="space-y-1">
+          <CardTitle className="text-2xl">AgentForge</CardTitle>
+          <CardDescription>Enter your API secret to continue</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="token">API Secret</Label>
+              <Input
+                id="token"
+                type="password"
+                placeholder="••••••••"
+                value={tokenValue}
+                onChange={(e) => setTokenValue(e.target.value)}
+                disabled={loading}
+                autoFocus
+                autoComplete="current-password"
+              />
+            </div>
+
+            {error && (
+              <p className="text-sm text-destructive">{error}</p>
+            )}
+
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="remember"
+                checked={remember}
+                onCheckedChange={setRemember}
+                disabled={loading}
+              />
+              <Label htmlFor="remember" className="font-normal cursor-pointer">
+                Remember me
+              </Label>
+            </div>
+
+            <Button type="submit" className="w-full" disabled={loading || !tokenValue}>
+              {loading ? 'Verifying…' : 'Sign in'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds `tests/execution/review-workflow.test.js` with 18 tests for `src/execution/review-workflow.js`
- Tests `needsReview()`: false for unknown agent, no `require_review`, no reviewer; true when both set
- Tests `_buildReviewPrompt()`: includes task title, type, model; APPROVE/REJECT instruction; result content; 2000-char truncation; empty/undefined result → `"(no result)"`
- Tests `submitForReview()`: no-reviewer early return, `review.submitted` event, feedback approval/rejection detection (case-insensitive), `review.completed` event, error handling from `comm.ask()`

## Test plan
- [ ] `node --test tests/execution/review-workflow.test.js` — 18 tests pass

https://claude.ai/code/session_0145JmbX6SnndfRd92nirCeX