### PR TITLE
test(providers): add interface.js unit tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,7 +41,7 @@ jobs:
         run: npx playwright test --config e2e/playwright.config.ts --project chromium
 
       - name: Upload test report
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b  # v4.3.6
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v4.3.6
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
              agentforge-v${{ steps.version.outputs.VERSION }}.tgz
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2
         with:
           generate_release_notes: true
           files: agentforge-v${{ steps.version.outputs.VERSION }}.tgz

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -27,7 +27,7 @@ jobs:
           results_format: sarif
           publish_results: true
       - name: Upload SARIF results to Security tab
-        uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e  # v4.32.4
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4.34.1
         with:
           sarif_file: results.sarif
           category: scorecard

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -40,10 +40,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@89a39a4e59826350b863aa6b6252a07ad50cf83e  # v4.32.4
+        uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4.34.1
         with:
           languages: javascript
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@89a39a4e59826350b863aa6b6252a07ad50cf83e  # v4.32.4
+        uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4.34.1
         with:
           category: '/language:javascript'

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 .env
 agentforge.yml
+.claude/
 *.db
 *.sqlite
 dist/

--- a/agentforge.example.yml
+++ b/agentforge.example.yml
@@ -220,3 +220,6 @@ alerts:
 server:
   port: 4242
   host: localhost
+  auth:
+    enabled: false          # Set to true + provide secret for production
+    secret: ${AGENTFORGE_SECRET}

--- a/e2e/tests/login.spec.ts
+++ b/e2e/tests/login.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from './fixtures'
+
+/**
+ * Login UI — auth bypass tests.
+ *
+ * The E2E server runs with auth disabled (default config), so:
+ * - /api/status returns 200 without a token
+ * - The AuthProvider auto-authenticates and skips the login page
+ * - All views remain accessible without any token in storage
+ */
+
+test.describe('Login — auth bypass when auth is disabled', () => {
+  test('login page redirects to dashboard when auth is disabled', async ({ page }) => {
+    await page.goto('/login')
+    // With auth disabled, AuthProvider sets isAuthenticated = true automatically,
+    // so LoginView redirects to /dashboard.
+    await expect(page).toHaveURL(/\/dashboard/, { timeout: 5000 })
+  })
+
+  test('navigating to / redirects to /dashboard without login', async ({ page }) => {
+    await page.goto('/')
+    await expect(page).toHaveURL(/\/dashboard/)
+  })
+
+  test('dashboard is accessible without a token when auth disabled', async ({ page }) => {
+    await page.goto('/dashboard')
+    await expect(page.getByRole('link', { name: 'Dashboard' })).toBeVisible()
+    await expect(page.locator('body')).not.toContainText('Something went wrong')
+  })
+
+  test('kanban is accessible without a token when auth disabled', async ({ page }) => {
+    await page.goto('/kanban')
+    await expect(page.getByRole('link', { name: 'Kanban' })).toBeVisible()
+    await expect(page.locator('body')).not.toContainText('Something went wrong')
+  })
+
+  test('agents is accessible without a token when auth disabled', async ({ page }) => {
+    await page.goto('/agents')
+    await expect(page.getByRole('link', { name: 'Agents' })).toBeVisible()
+    await expect(page.locator('body')).not.toContainText('Something went wrong')
+  })
+
+  test('providers is accessible without a token when auth disabled', async ({ page }) => {
+    await page.goto('/providers')
+    await expect(page.getByRole('link', { name: 'Providers' })).toBeVisible()
+    await expect(page.locator('body')).not.toContainText('Something went wrong')
+  })
+
+  test('costs is accessible without a token when auth disabled', async ({ page }) => {
+    await page.goto('/costs')
+    await page.waitForLoadState('networkidle')
+    const content = page.getByText('Total Spend').or(page.getByText('Cost tracking not available.'))
+    await expect(content.first()).toBeVisible()
+    await expect(page.locator('body')).not.toContainText('Something went wrong')
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -2116,9 +2116,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -16,6 +16,7 @@ import express from 'express';
 import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
 import { startWebSocketServer } from './ws.js';
+import { createAuthMiddleware } from '../auth/auth.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -507,6 +508,9 @@ export function startServer(forge, port = 3000, host = '127.0.0.1') {
   // CORS — must be before routes
   app.use(corsMiddleware);
 
+  // Auth — must be before rate limiters and router
+  app.use('/api', createAuthMiddleware(forge.config?.server?.auth ?? {}));
+
   // Rate limiting — scoped to API routes only (not static files)
   app.use('/api', generalLimiter);
   app.post('/api/*splat', mutationLimiter);
@@ -528,7 +532,11 @@ export function startServer(forge, port = 3000, host = '127.0.0.1') {
 
   // Create the HTTP server and attach the WebSocket server
   const httpServer = http.createServer(app);
-  startWebSocketServer(httpServer, forge.eventBus);
+  startWebSocketServer(httpServer, forge.eventBus, forge.config?.server?.auth ?? {});
+
+  if (!forge.config?.server?.auth?.enabled) {
+    console.warn('[agentforge:api] WARNING: API auth is disabled — set server.auth.secret in agentforge.yml for production use');
+  }
 
   httpServer.listen(port, host, () => {
     console.log('[agentforge:api] REST API listening on http://%s:%d', host, port);

--- a/src/api/ws.js
+++ b/src/api/ws.js
@@ -10,6 +10,7 @@
  */
 
 import { WebSocketServer } from 'ws';
+import { timingSafeEqual } from 'node:crypto';
 
 // ---------------------------------------------------------------------------
 // Event list — all events that are broadcast to connected clients
@@ -59,6 +60,23 @@ function broadcast(wss, message) {
 }
 
 /**
+ * Constant-time token comparison to prevent timing side-channel attacks.
+ *
+ * @param {string} a
+ * @param {string} b
+ * @returns {boolean}
+ */
+function wsTokenEqual(a, b) {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) {
+    timingSafeEqual(bufA, bufA);
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
+}
+
+/**
  * Send a single message to a specific client, ignoring send errors
  * (the client may have disconnected between the readyState check and send).
  *
@@ -85,6 +103,10 @@ function sendToClient(ws, message) {
  * The WebSocket endpoint is mounted at `/ws` on the same port as the REST API.
  *
  * Behaviour per connection:
+ *  - When `authConfig.enabled` is true (and `NODE_ENV !== 'test'`), the
+ *    connecting client must supply the shared secret as a `?token=<secret>`
+ *    query parameter.  Connections without a valid token are closed with code
+ *    4401 and the message "Unauthorized".
  *  - Replays the last 20 events immediately on connect.
  *  - Forwards every listed event from the eventBus as it fires.
  *  - Sends a ping frame every 30 s; closes the connection if no pong is
@@ -93,6 +115,7 @@ function sendToClient(ws, message) {
  *
  * @param {import('http').Server} httpServer - The Node.js HTTP server to attach to.
  * @param {import('../core/event-bus.js').default} eventBus - The AgentForge event bus singleton.
+ * @param {{ enabled?: boolean, secret?: string }} [authConfig={}] - Auth config.
  * @returns {WebSocketServer} The created WebSocket server instance.
  *
  * @example
@@ -103,14 +126,23 @@ function sendToClient(ws, message) {
  *
  * const app = express();
  * const httpServer = http.createServer(app);
- * startWebSocketServer(httpServer, eventBus);
+ * startWebSocketServer(httpServer, eventBus, { enabled: false });
  * httpServer.listen(3000);
  */
-export function startWebSocketServer(httpServer, eventBus) {
+export function startWebSocketServer(httpServer, eventBus, authConfig = {}) {
   const wss = new WebSocketServer({ server: httpServer, path: '/ws' });
 
   // ── Per-connection logic ─────────────────────────────────────────────────
-  wss.on('connection', (ws) => {
+  wss.on('connection', (ws, req) => {
+    // Token auth check for WebSocket connections
+    if (authConfig.enabled && process.env.NODE_ENV !== 'test') {
+      const url = new URL(req.url, 'http://localhost');
+      const token = url.searchParams.get('token');
+      if (!token || !authConfig.secret || !wsTokenEqual(token, authConfig.secret)) {
+        ws.close(4401, 'Unauthorized');
+        return;
+      }
+    }
     // Replay the last 20 events so the dashboard can hydrate immediately
     const recent = eventBus.getRecentEvents(20);
     for (const entry of recent) {

--- a/src/auth/auth.js
+++ b/src/auth/auth.js
@@ -1,0 +1,86 @@
+/**
+ * @file src/auth/auth.js
+ * @description Static Bearer-token authentication middleware for AgentForge.
+ *
+ * GitHub issue #93
+ */
+
+import { timingSafeEqual } from 'node:crypto';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Constant-time string comparison using Node's crypto.timingSafeEqual to
+ * prevent timing side-channel attacks when comparing secrets.
+ *
+ * @param {string} a
+ * @param {string} b
+ * @returns {boolean}
+ */
+function safeEqual(a, b) {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) {
+    // Lengths differ — still run timingSafeEqual on equal-length buffers to
+    // avoid a length-based timing leak, then return false.
+    timingSafeEqual(bufA, bufA);
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Create an Express middleware that enforces Bearer-token authentication.
+ *
+ * Behaviour:
+ * - If `authConfig.enabled` is falsy → calls `next()` immediately (auth off).
+ * - If `NODE_ENV === 'test'` → calls `next()` immediately (test bypass).
+ * - Exempts `GET /api/status` so load-balancers can perform health checks
+ *   without a token.
+ * - Reads the `Authorization: Bearer <token>` header and compares it to
+ *   `authConfig.secret` using a constant-time comparison.
+ * - Returns `401 { ok: false, error: "Unauthorized" }` if the token is
+ *   missing or incorrect.
+ *
+ * @param {{ enabled?: boolean, secret?: string }} authConfig
+ * @returns {import('express').RequestHandler}
+ *
+ * @example
+ * import { createAuthMiddleware } from '../auth/auth.js';
+ * app.use('/api', createAuthMiddleware(forge.config?.server?.auth ?? {}));
+ */
+export function createAuthMiddleware(authConfig = {}) {
+  return function authMiddleware(req, res, next) {
+    // Bypass in test environment
+    if (process.env.NODE_ENV === 'test') {
+      return next();
+    }
+
+    // Bypass when auth is disabled
+    if (!authConfig.enabled) {
+      return next();
+    }
+
+    // Health-check exemption — always allow GET /api/status
+    if (req.method === 'GET' && req.path === '/status') {
+      return next();
+    }
+
+    // Extract Bearer token from Authorization header
+    const authHeader = req.headers['authorization'] ?? '';
+    const match = /^Bearer\s+(\S+)$/i.exec(authHeader);
+    const token = match ? match[1] : null;
+
+    if (!token || !authConfig.secret || !safeEqual(token, authConfig.secret)) {
+      return res.status(401).json({ ok: false, error: 'Unauthorized' });
+    }
+
+    return next();
+  };
+}

--- a/tests/api/auth.test.js
+++ b/tests/api/auth.test.js
@@ -1,0 +1,169 @@
+/**
+ * @file tests/api/auth.test.js
+ * @description Unit tests for src/auth/auth.js createAuthMiddleware.
+ *
+ * GitHub issue #93
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createAuthMiddleware } from '../../src/auth/auth.js';
+
+// ---------------------------------------------------------------------------
+// Helpers — minimal req/res/next stubs
+// ---------------------------------------------------------------------------
+
+function makeReq({ method = 'GET', path = '/tasks', authorization } = {}) {
+  return {
+    method,
+    path,
+    headers: authorization ? { authorization } : {},
+  };
+}
+
+function makeRes() {
+  const res = {
+    _status: null,
+    _body: null,
+    status(code) {
+      this._status = code;
+      return this;
+    },
+    json(body) {
+      this._body = body;
+      return this;
+    },
+  };
+  return res;
+}
+
+function makeNext() {
+  let called = false;
+  const fn = () => { called = true; };
+  fn.wasCalled = () => called;
+  return fn;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createAuthMiddleware', () => {
+  const SECRET = 'test-secret-abc123';
+
+  // Save and restore NODE_ENV around tests that mutate it
+  let savedNodeEnv;
+  beforeEach(() => { savedNodeEnv = process.env.NODE_ENV; });
+  afterEach(() => { process.env.NODE_ENV = savedNodeEnv; });
+
+  // ── auth disabled ────────────────────────────────────────────────────────
+
+  it('calls next() immediately when enabled=false', () => {
+    const mw = createAuthMiddleware({ enabled: false, secret: SECRET });
+    const req = makeReq({ authorization: undefined });
+    const res = makeRes();
+    const next = makeNext();
+
+    process.env.NODE_ENV = 'production'; // ensure not in test bypass
+    mw(req, res, next);
+
+    assert.ok(next.wasCalled(), 'next should be called');
+    assert.equal(res._status, null, 'should not set status');
+  });
+
+  it('calls next() when authConfig is empty object (enabled falsy)', () => {
+    const mw = createAuthMiddleware({});
+    const next = makeNext();
+    process.env.NODE_ENV = 'production';
+    mw(makeReq(), makeRes(), next);
+    assert.ok(next.wasCalled());
+  });
+
+  // ── NODE_ENV=test bypass ─────────────────────────────────────────────────
+
+  it('calls next() in test environment regardless of enabled=true', () => {
+    process.env.NODE_ENV = 'test';
+    const mw = createAuthMiddleware({ enabled: true, secret: SECRET });
+    const next = makeNext();
+    // No Authorization header — should still pass
+    mw(makeReq(), makeRes(), next);
+    assert.ok(next.wasCalled());
+  });
+
+  it('calls next() in test environment with wrong token', () => {
+    process.env.NODE_ENV = 'test';
+    const mw = createAuthMiddleware({ enabled: true, secret: SECRET });
+    const next = makeNext();
+    mw(makeReq({ authorization: 'Bearer wrong-token' }), makeRes(), next);
+    assert.ok(next.wasCalled());
+  });
+
+  // ── auth enabled, correct token ──────────────────────────────────────────
+
+  it('calls next() when enabled=true and correct Bearer token is provided', () => {
+    process.env.NODE_ENV = 'production';
+    const mw = createAuthMiddleware({ enabled: true, secret: SECRET });
+    const next = makeNext();
+    mw(makeReq({ authorization: `Bearer ${SECRET}` }), makeRes(), next);
+    assert.ok(next.wasCalled());
+  });
+
+  // ── auth enabled, wrong token ────────────────────────────────────────────
+
+  it('returns 401 when enabled=true and wrong token is provided', () => {
+    process.env.NODE_ENV = 'production';
+    const mw = createAuthMiddleware({ enabled: true, secret: SECRET });
+    const res = makeRes();
+    const next = makeNext();
+    mw(makeReq({ authorization: 'Bearer wrong-token' }), res, next);
+    assert.equal(res._status, 401);
+    assert.deepEqual(res._body, { ok: false, error: 'Unauthorized' });
+    assert.ok(!next.wasCalled());
+  });
+
+  // ── auth enabled, no Authorization header ────────────────────────────────
+
+  it('returns 401 when enabled=true and no Authorization header', () => {
+    process.env.NODE_ENV = 'production';
+    const mw = createAuthMiddleware({ enabled: true, secret: SECRET });
+    const res = makeRes();
+    const next = makeNext();
+    mw(makeReq(), res, next);
+    assert.equal(res._status, 401);
+    assert.deepEqual(res._body, { ok: false, error: 'Unauthorized' });
+    assert.ok(!next.wasCalled());
+  });
+
+  it('returns 401 when Authorization header has wrong scheme', () => {
+    process.env.NODE_ENV = 'production';
+    const mw = createAuthMiddleware({ enabled: true, secret: SECRET });
+    const res = makeRes();
+    const next = makeNext();
+    mw(makeReq({ authorization: `Basic ${SECRET}` }), res, next);
+    assert.equal(res._status, 401);
+    assert.ok(!next.wasCalled());
+  });
+
+  // ── health-check exemption ───────────────────────────────────────────────
+
+  it('passes GET /api/status through even when enabled=true and no token', () => {
+    process.env.NODE_ENV = 'production';
+    // The middleware is mounted at /api, so req.path is /status (not /api/status)
+    const mw = createAuthMiddleware({ enabled: true, secret: SECRET });
+    const next = makeNext();
+    const req = makeReq({ method: 'GET', path: '/status' });
+    mw(req, makeRes(), next);
+    assert.ok(next.wasCalled());
+  });
+
+  it('does NOT exempt POST /api/status from auth', () => {
+    process.env.NODE_ENV = 'production';
+    const mw = createAuthMiddleware({ enabled: true, secret: SECRET });
+    const res = makeRes();
+    const next = makeNext();
+    const req = makeReq({ method: 'POST', path: '/status' });
+    mw(req, res, next);
+    assert.equal(res._status, 401);
+    assert.ok(!next.wasCalled());
+  });
+});

--- a/tests/providers/interface.test.js
+++ b/tests/providers/interface.test.js
@@ -1,0 +1,244 @@
+/**
+ * @file tests/providers/interface.test.js
+ * @description Unit tests for src/providers/interface.js —
+ *   BaseProvider, OllamaProvider, and ProviderRegistry.
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { BaseProvider, OllamaProvider, ProviderRegistry } from '../../src/providers/interface.js';
+
+// ---------------------------------------------------------------------------
+// BaseProvider
+// ---------------------------------------------------------------------------
+
+describe('BaseProvider', () => {
+  it('stores id, endpoint, and apiKey from config', () => {
+    const p = new BaseProvider('my-provider', { endpoint: 'https://api.example.com', api_key: 'key123' });
+    assert.equal(p.id, 'my-provider');
+    assert.equal(p.endpoint, 'https://api.example.com');
+    assert.equal(p.apiKey, 'key123');
+  });
+
+  it('uses empty strings for missing config fields', () => {
+    const p = new BaseProvider('bare');
+    assert.equal(p.endpoint, '');
+    assert.equal(p.apiKey, '');
+  });
+
+  it('execute() throws "not implemented"', async () => {
+    const p = new BaseProvider('test');
+    await assert.rejects(() => p.execute({}), /not implemented/);
+  });
+
+  it('listModels() throws "not implemented"', async () => {
+    const p = new BaseProvider('test');
+    await assert.rejects(() => p.listModels(), /not implemented/);
+  });
+
+  it('healthCheck() throws "not implemented"', async () => {
+    const p = new BaseProvider('test');
+    await assert.rejects(() => p.healthCheck(), /not implemented/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OllamaProvider
+// ---------------------------------------------------------------------------
+
+describe('OllamaProvider', () => {
+  it('defaults to localhost:11434 endpoint', () => {
+    const p = new OllamaProvider();
+    assert.equal(p.id, 'ollama');
+    assert.equal(p.endpoint, 'http://localhost:11434');
+  });
+
+  it('accepts a custom endpoint', () => {
+    const p = new OllamaProvider({ endpoint: 'http://192.168.1.5:11434' });
+    assert.equal(p.endpoint, 'http://192.168.1.5:11434');
+  });
+
+  it('execute() returns normalised response shape on success', async () => {
+    const p = new OllamaProvider({ endpoint: 'http://localhost:11434' });
+
+    // Stub global fetch
+    const original = globalThis.fetch;
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({
+        message: { content: 'Hello from Ollama' },
+        prompt_eval_count: 10,
+        eval_count: 20,
+      }),
+    });
+
+    try {
+      const result = await p.execute({
+        model: 'llama3',
+        messages: [{ role: 'user', content: 'hi' }],
+      });
+      assert.equal(result.content, 'Hello from Ollama');
+      assert.equal(result.tokens_in, 10);
+      assert.equal(result.tokens_out, 20);
+      assert.deepEqual(result.tool_calls, []);
+      assert.equal(result.finish_reason, 'stop');
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it('execute() defaults tokens to 0 when counts are missing', async () => {
+    const p = new OllamaProvider();
+    const original = globalThis.fetch;
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({ message: { content: 'ok' } }),
+    });
+    try {
+      const result = await p.execute({ model: 'llama3', messages: [] });
+      assert.equal(result.tokens_in, 0);
+      assert.equal(result.tokens_out, 0);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it('execute() throws on non-ok HTTP response', async () => {
+    const p = new OllamaProvider();
+    const original = globalThis.fetch;
+    globalThis.fetch = async () => ({
+      ok: false,
+      status: 503,
+      text: async () => 'Service Unavailable',
+    });
+    try {
+      await assert.rejects(
+        () => p.execute({ model: 'llama3', messages: [] }),
+        /Ollama error 503/
+      );
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it('listModels() returns model names on success', async () => {
+    const p = new OllamaProvider();
+    const original = globalThis.fetch;
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({ models: [{ name: 'llama3' }, { name: 'mistral' }] }),
+    });
+    try {
+      const models = await p.listModels();
+      assert.deepEqual(models, ['llama3', 'mistral']);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it('listModels() returns empty array on non-ok response', async () => {
+    const p = new OllamaProvider();
+    const original = globalThis.fetch;
+    globalThis.fetch = async () => ({ ok: false });
+    try {
+      const models = await p.listModels();
+      assert.deepEqual(models, []);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it('healthCheck() returns true when endpoint responds ok', async () => {
+    const p = new OllamaProvider();
+    const original = globalThis.fetch;
+    globalThis.fetch = async () => ({ ok: true });
+    try {
+      assert.equal(await p.healthCheck(), true);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it('healthCheck() returns false when fetch throws (unreachable)', async () => {
+    const p = new OllamaProvider();
+    const original = globalThis.fetch;
+    globalThis.fetch = async () => { throw new Error('ECONNREFUSED'); };
+    try {
+      assert.equal(await p.healthCheck(), false);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it('healthCheck() returns false when endpoint responds not-ok', async () => {
+    const p = new OllamaProvider();
+    const original = globalThis.fetch;
+    globalThis.fetch = async () => ({ ok: false });
+    try {
+      assert.equal(await p.healthCheck(), false);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ProviderRegistry
+// ---------------------------------------------------------------------------
+
+describe('ProviderRegistry', () => {
+  let registry;
+
+  beforeEach(() => {
+    registry = new ProviderRegistry();
+  });
+
+  it('starts empty', () => {
+    assert.equal(registry.providers.size, 0);
+  });
+
+  it('register() and get() roundtrip', () => {
+    const p = new OllamaProvider();
+    registry.register(p);
+    assert.equal(registry.get('ollama'), p);
+  });
+
+  it('get() returns null for unknown provider', () => {
+    assert.equal(registry.get('unknown'), null);
+  });
+
+  it('execute() calls provider.execute() with correct params', async () => {
+    let capturedParams;
+    const fake = {
+      id: 'fake',
+      execute: async (params) => {
+        capturedParams = params;
+        return { content: 'done', tokens_in: 1, tokens_out: 2, tool_calls: [], finish_reason: 'stop' };
+      },
+    };
+    registry.register(fake);
+    const result = await registry.execute('fake', { model: 'x', messages: [] });
+    assert.equal(result.content, 'done');
+    assert.deepEqual(capturedParams, { model: 'x', messages: [] });
+  });
+
+  it('execute() throws when provider not found', async () => {
+    await assert.rejects(
+      () => registry.execute('missing', {}),
+      /Provider not found: missing/
+    );
+  });
+
+  it('healthCheckAll() aggregates results from all providers', async () => {
+    registry.register({ id: 'a', healthCheck: async () => true });
+    registry.register({ id: 'b', healthCheck: async () => false });
+    const results = await registry.healthCheckAll();
+    assert.equal(results.a, true);
+    assert.equal(results.b, false);
+  });
+
+  it('healthCheckAll() returns empty object when no providers registered', async () => {
+    const results = await registry.healthCheckAll();
+    assert.deepEqual(results, {});
+  });
+});

--- a/tests/providers/interface.test.js
+++ b/tests/providers/interface.test.js
@@ -1,44 +1,103 @@
 /**
  * @file tests/providers/interface.test.js
- * @description Unit tests for src/providers/interface.js —
- *   BaseProvider, OllamaProvider, and ProviderRegistry.
+ * @description Unit tests for src/providers/interface.js
+ *
+ * Covers:
+ *  - BaseProvider: constructor, execute/listModels/healthCheck throw "not implemented"
+ *  - OllamaProvider: constructor defaults, execute() parses Ollama response,
+ *    execute() throws on HTTP error, listModels(), healthCheck()
+ *  - ProviderRegistry: register/get, execute() delegates, execute() throws for
+ *    unknown provider, healthCheckAll()
  */
 
-import { describe, it, beforeEach } from 'node:test';
+import { describe, it, before, after, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
+import http from 'node:http';
 import { BaseProvider, OllamaProvider, ProviderRegistry } from '../../src/providers/interface.js';
+
+// ---------------------------------------------------------------------------
+// Helpers — minimal Ollama HTTP stub
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a tiny HTTP server that responds to Ollama API paths.
+ * Returns { server, port, setResponse }.
+ */
+function createOllamaStub() {
+  let responseConfig = {
+    '/api/chat': {
+      status: 200,
+      body: {
+        message: { content: 'Hello from Ollama' },
+        prompt_eval_count: 10,
+        eval_count: 20,
+      },
+    },
+    '/api/tags': {
+      status: 200,
+      body: { models: [{ name: 'llama3' }, { name: 'mistral' }] },
+    },
+  };
+
+  const server = http.createServer((req, res) => {
+    const cfg = responseConfig[req.url] || { status: 404, body: { error: 'not found' } };
+    res.writeHead(cfg.status, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(cfg.body));
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      const endpoint = `http://127.0.0.1:${port}`;
+      resolve({
+        server,
+        port,
+        endpoint,
+        setRoute(path, status, body) {
+          responseConfig[path] = { status, body };
+        },
+      });
+    });
+  });
+}
 
 // ---------------------------------------------------------------------------
 // BaseProvider
 // ---------------------------------------------------------------------------
 
 describe('BaseProvider', () => {
-  it('stores id, endpoint, and apiKey from config', () => {
-    const p = new BaseProvider('my-provider', { endpoint: 'https://api.example.com', api_key: 'key123' });
-    assert.equal(p.id, 'my-provider');
-    assert.equal(p.endpoint, 'https://api.example.com');
-    assert.equal(p.apiKey, 'key123');
+  it('constructor sets id, endpoint, apiKey from config', () => {
+    const p = new BaseProvider('test-provider', { endpoint: 'https://api.test.com', api_key: 'sk-123' });
+    assert.equal(p.id, 'test-provider');
+    assert.equal(p.endpoint, 'https://api.test.com');
+    assert.equal(p.apiKey, 'sk-123');
   });
 
-  it('uses empty strings for missing config fields', () => {
+  it('constructor uses empty defaults when config is omitted', () => {
     const p = new BaseProvider('bare');
+    assert.equal(p.id, 'bare');
     assert.equal(p.endpoint, '');
     assert.equal(p.apiKey, '');
   });
 
-  it('execute() throws "not implemented"', async () => {
-    const p = new BaseProvider('test');
+  it('execute() throws "not implemented" error', async () => {
+    const p = new BaseProvider('x');
     await assert.rejects(() => p.execute({}), /not implemented/);
   });
 
-  it('listModels() throws "not implemented"', async () => {
-    const p = new BaseProvider('test');
+  it('listModels() throws "not implemented" error', async () => {
+    const p = new BaseProvider('x');
     await assert.rejects(() => p.listModels(), /not implemented/);
   });
 
-  it('healthCheck() throws "not implemented"', async () => {
-    const p = new BaseProvider('test');
+  it('healthCheck() throws "not implemented" error', async () => {
+    const p = new BaseProvider('x');
     await assert.rejects(() => p.healthCheck(), /not implemented/);
+  });
+
+  it('error messages include the provider id', async () => {
+    const p = new BaseProvider('my-provider');
+    await assert.rejects(() => p.execute({}), /my-provider/);
   });
 });
 
@@ -47,138 +106,90 @@ describe('BaseProvider', () => {
 // ---------------------------------------------------------------------------
 
 describe('OllamaProvider', () => {
-  it('defaults to localhost:11434 endpoint', () => {
+  let stub;
+
+  before(async () => { stub = await createOllamaStub(); });
+  after(() => new Promise((resolve) => stub.server.close(resolve)));
+
+  it('constructor defaults endpoint to http://localhost:11434', () => {
     const p = new OllamaProvider();
-    assert.equal(p.id, 'ollama');
     assert.equal(p.endpoint, 'http://localhost:11434');
+    assert.equal(p.id, 'ollama');
   });
 
-  it('accepts a custom endpoint', () => {
-    const p = new OllamaProvider({ endpoint: 'http://192.168.1.5:11434' });
-    assert.equal(p.endpoint, 'http://192.168.1.5:11434');
+  it('constructor accepts a custom endpoint', () => {
+    const p = new OllamaProvider({ endpoint: 'http://remote:11434' });
+    assert.equal(p.endpoint, 'http://remote:11434');
   });
 
-  it('execute() returns normalised response shape on success', async () => {
-    const p = new OllamaProvider({ endpoint: 'http://localhost:11434' });
+  it('execute() returns normalised response shape', async () => {
+    const p = new OllamaProvider({ endpoint: stub.endpoint });
+    const result = await p.execute({ model: 'llama3', messages: [{ role: 'user', content: 'hi' }] });
+    assert.equal(result.content, 'Hello from Ollama');
+    assert.equal(result.tokens_in, 10);
+    assert.equal(result.tokens_out, 20);
+    assert.deepEqual(result.tool_calls, []);
+    assert.equal(result.finish_reason, 'stop');
+  });
 
-    // Stub global fetch
-    const original = globalThis.fetch;
-    globalThis.fetch = async () => ({
-      ok: true,
-      json: async () => ({
-        message: { content: 'Hello from Ollama' },
-        prompt_eval_count: 10,
-        eval_count: 20,
-      }),
+  it('execute() throws on non-OK HTTP status', async () => {
+    stub.setRoute('/api/chat', 500, { error: 'Internal Server Error' });
+    const p = new OllamaProvider({ endpoint: stub.endpoint });
+    await assert.rejects(
+      () => p.execute({ model: 'llama3', messages: [] }),
+      /Ollama error 500/,
+    );
+    // restore
+    stub.setRoute('/api/chat', 200, {
+      message: { content: 'Hello from Ollama' },
+      prompt_eval_count: 10,
+      eval_count: 20,
     });
-
-    try {
-      const result = await p.execute({
-        model: 'llama3',
-        messages: [{ role: 'user', content: 'hi' }],
-      });
-      assert.equal(result.content, 'Hello from Ollama');
-      assert.equal(result.tokens_in, 10);
-      assert.equal(result.tokens_out, 20);
-      assert.deepEqual(result.tool_calls, []);
-      assert.equal(result.finish_reason, 'stop');
-    } finally {
-      globalThis.fetch = original;
-    }
   });
 
-  it('execute() defaults tokens to 0 when counts are missing', async () => {
-    const p = new OllamaProvider();
-    const original = globalThis.fetch;
-    globalThis.fetch = async () => ({
-      ok: true,
-      json: async () => ({ message: { content: 'ok' } }),
+  it('execute() handles missing token counts (defaults to 0)', async () => {
+    stub.setRoute('/api/chat', 200, { message: { content: 'sparse' } });
+    const p = new OllamaProvider({ endpoint: stub.endpoint });
+    const result = await p.execute({ model: 'llama3', messages: [] });
+    assert.equal(result.tokens_in, 0);
+    assert.equal(result.tokens_out, 0);
+    // restore
+    stub.setRoute('/api/chat', 200, {
+      message: { content: 'Hello from Ollama' },
+      prompt_eval_count: 10,
+      eval_count: 20,
     });
-    try {
-      const result = await p.execute({ model: 'llama3', messages: [] });
-      assert.equal(result.tokens_in, 0);
-      assert.equal(result.tokens_out, 0);
-    } finally {
-      globalThis.fetch = original;
-    }
   });
 
-  it('execute() throws on non-ok HTTP response', async () => {
-    const p = new OllamaProvider();
-    const original = globalThis.fetch;
-    globalThis.fetch = async () => ({
-      ok: false,
-      status: 503,
-      text: async () => 'Service Unavailable',
-    });
-    try {
-      await assert.rejects(
-        () => p.execute({ model: 'llama3', messages: [] }),
-        /Ollama error 503/
-      );
-    } finally {
-      globalThis.fetch = original;
-    }
+  it('listModels() returns array of model name strings', async () => {
+    const p = new OllamaProvider({ endpoint: stub.endpoint });
+    const models = await p.listModels();
+    assert.deepEqual(models, ['llama3', 'mistral']);
   });
 
-  it('listModels() returns model names on success', async () => {
-    const p = new OllamaProvider();
-    const original = globalThis.fetch;
-    globalThis.fetch = async () => ({
-      ok: true,
-      json: async () => ({ models: [{ name: 'llama3' }, { name: 'mistral' }] }),
-    });
-    try {
-      const models = await p.listModels();
-      assert.deepEqual(models, ['llama3', 'mistral']);
-    } finally {
-      globalThis.fetch = original;
-    }
+  it('listModels() returns empty array on HTTP error', async () => {
+    stub.setRoute('/api/tags', 503, {});
+    const p = new OllamaProvider({ endpoint: stub.endpoint });
+    const models = await p.listModels();
+    assert.deepEqual(models, []);
+    stub.setRoute('/api/tags', 200, { models: [{ name: 'llama3' }, { name: 'mistral' }] });
   });
 
-  it('listModels() returns empty array on non-ok response', async () => {
-    const p = new OllamaProvider();
-    const original = globalThis.fetch;
-    globalThis.fetch = async () => ({ ok: false });
-    try {
-      const models = await p.listModels();
-      assert.deepEqual(models, []);
-    } finally {
-      globalThis.fetch = original;
-    }
+  it('healthCheck() returns true when server responds OK', async () => {
+    const p = new OllamaProvider({ endpoint: stub.endpoint });
+    assert.equal(await p.healthCheck(), true);
   });
 
-  it('healthCheck() returns true when endpoint responds ok', async () => {
-    const p = new OllamaProvider();
-    const original = globalThis.fetch;
-    globalThis.fetch = async () => ({ ok: true });
-    try {
-      assert.equal(await p.healthCheck(), true);
-    } finally {
-      globalThis.fetch = original;
-    }
+  it('healthCheck() returns false when server is unreachable', async () => {
+    const p = new OllamaProvider({ endpoint: 'http://127.0.0.1:1' }); // nothing listens on port 1
+    assert.equal(await p.healthCheck(), false);
   });
 
-  it('healthCheck() returns false when fetch throws (unreachable)', async () => {
-    const p = new OllamaProvider();
-    const original = globalThis.fetch;
-    globalThis.fetch = async () => { throw new Error('ECONNREFUSED'); };
-    try {
-      assert.equal(await p.healthCheck(), false);
-    } finally {
-      globalThis.fetch = original;
-    }
-  });
-
-  it('healthCheck() returns false when endpoint responds not-ok', async () => {
-    const p = new OllamaProvider();
-    const original = globalThis.fetch;
-    globalThis.fetch = async () => ({ ok: false });
-    try {
-      assert.equal(await p.healthCheck(), false);
-    } finally {
-      globalThis.fetch = original;
-    }
+  it('healthCheck() returns false on HTTP error status', async () => {
+    stub.setRoute('/api/tags', 503, {});
+    const p = new OllamaProvider({ endpoint: stub.endpoint });
+    assert.equal(await p.healthCheck(), false);
+    stub.setRoute('/api/tags', 200, { models: [{ name: 'llama3' }, { name: 'mistral' }] });
   });
 });
 
@@ -187,58 +198,63 @@ describe('OllamaProvider', () => {
 // ---------------------------------------------------------------------------
 
 describe('ProviderRegistry', () => {
-  let registry;
-
-  beforeEach(() => {
-    registry = new ProviderRegistry();
-  });
-
-  it('starts empty', () => {
-    assert.equal(registry.providers.size, 0);
-  });
-
-  it('register() and get() roundtrip', () => {
-    const p = new OllamaProvider();
-    registry.register(p);
-    assert.equal(registry.get('ollama'), p);
-  });
+  /** Minimal provider stub */
+  function makeProvider(id, executeResult = { content: 'ok', tokens_in: 1, tokens_out: 1, tool_calls: [], finish_reason: 'stop' }) {
+    return {
+      id,
+      execute: async (_params) => executeResult,
+      healthCheck: async () => true,
+    };
+  }
 
   it('get() returns null for unknown provider', () => {
-    assert.equal(registry.get('unknown'), null);
+    const reg = new ProviderRegistry();
+    assert.equal(reg.get('missing'), null);
   });
 
-  it('execute() calls provider.execute() with correct params', async () => {
-    let capturedParams;
-    const fake = {
-      id: 'fake',
-      execute: async (params) => {
-        capturedParams = params;
-        return { content: 'done', tokens_in: 1, tokens_out: 2, tool_calls: [], finish_reason: 'stop' };
-      },
-    };
-    registry.register(fake);
-    const result = await registry.execute('fake', { model: 'x', messages: [] });
-    assert.equal(result.content, 'done');
-    assert.deepEqual(capturedParams, { model: 'x', messages: [] });
+  it('register() + get() round-trip', () => {
+    const reg = new ProviderRegistry();
+    const p = makeProvider('anthropic');
+    reg.register(p);
+    assert.equal(reg.get('anthropic'), p);
   });
 
-  it('execute() throws when provider not found', async () => {
-    await assert.rejects(
-      () => registry.execute('missing', {}),
-      /Provider not found: missing/
-    );
+  it('execute() delegates to the registered provider', async () => {
+    const reg = new ProviderRegistry();
+    reg.register(makeProvider('anthropic', { content: 'delegate works', tokens_in: 5, tokens_out: 8, tool_calls: [], finish_reason: 'stop' }));
+    const result = await reg.execute('anthropic', { model: 'claude-opus-4-6', messages: [] });
+    assert.equal(result.content, 'delegate works');
+    assert.equal(result.tokens_in, 5);
   });
 
-  it('healthCheckAll() aggregates results from all providers', async () => {
-    registry.register({ id: 'a', healthCheck: async () => true });
-    registry.register({ id: 'b', healthCheck: async () => false });
-    const results = await registry.healthCheckAll();
+  it('execute() throws when provider is not registered', async () => {
+    const reg = new ProviderRegistry();
+    await assert.rejects(() => reg.execute('unknown', {}), /Provider not found: unknown/);
+  });
+
+  it('healthCheckAll() returns a map of provider → boolean', async () => {
+    const reg = new ProviderRegistry();
+    const healthy = { ...makeProvider('a'), healthCheck: async () => true };
+    const unhealthy = { ...makeProvider('b'), healthCheck: async () => false };
+    reg.register(healthy);
+    reg.register(unhealthy);
+    const results = await reg.healthCheckAll();
     assert.equal(results.a, true);
     assert.equal(results.b, false);
   });
 
-  it('healthCheckAll() returns empty object when no providers registered', async () => {
-    const results = await registry.healthCheckAll();
+  it('healthCheckAll() returns empty object when no providers are registered', async () => {
+    const reg = new ProviderRegistry();
+    const results = await reg.healthCheckAll();
     assert.deepEqual(results, {});
+  });
+
+  it('register() overwrites a provider with the same id', () => {
+    const reg = new ProviderRegistry();
+    const p1 = makeProvider('x');
+    const p2 = makeProvider('x');
+    reg.register(p1);
+    reg.register(p2);
+    assert.equal(reg.get('x'), p2);
   });
 });

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1980,6 +1980,70 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.1.tgz",
@@ -3049,9 +3113,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,27 +1,44 @@
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Navigate, Outlet, useLocation } from 'react-router-dom'
 import { WebSocketProvider } from '@/contexts/WebSocketContext'
+import { AuthProvider, useAuth } from '@/contexts/AuthContext'
 import { Layout } from '@/components/layout/Layout'
 import DashboardView from '@/views/DashboardView'
 import KanbanView from '@/views/KanbanView'
 import AgentsView from '@/views/AgentsView'
 import ProvidersView from '@/views/ProvidersView'
 import CostsView from '@/views/CostsView'
+import LoginView from '@/views/LoginView'
+
+function ProtectedRoute() {
+  const { isAuthenticated } = useAuth()
+  const location = useLocation()
+  if (!isAuthenticated) {
+    const redirect = location.pathname + location.search
+    return <Navigate to={`/login?redirect=${encodeURIComponent(redirect)}`} replace />
+  }
+  return <Outlet />
+}
 
 export default function App() {
   return (
     <BrowserRouter>
-      <WebSocketProvider>
-        <Routes>
-          <Route element={<Layout />}>
-            <Route index element={<Navigate to="/dashboard" replace />} />
-            <Route path="/dashboard" element={<DashboardView />} />
-            <Route path="/kanban" element={<KanbanView />} />
-            <Route path="/agents" element={<AgentsView />} />
-            <Route path="/providers" element={<ProvidersView />} />
-            <Route path="/costs" element={<CostsView />} />
-          </Route>
-        </Routes>
-      </WebSocketProvider>
+      <AuthProvider>
+        <WebSocketProvider>
+          <Routes>
+            <Route path="/login" element={<LoginView />} />
+            <Route element={<ProtectedRoute />}>
+              <Route element={<Layout />}>
+                <Route index element={<Navigate to="/dashboard" replace />} />
+                <Route path="/dashboard" element={<DashboardView />} />
+                <Route path="/kanban" element={<KanbanView />} />
+                <Route path="/agents" element={<AgentsView />} />
+                <Route path="/providers" element={<ProvidersView />} />
+                <Route path="/costs" element={<CostsView />} />
+              </Route>
+            </Route>
+          </Routes>
+        </WebSocketProvider>
+      </AuthProvider>
     </BrowserRouter>
   )
 }

--- a/ui/src/components/ui/checkbox.tsx
+++ b/ui/src/components/ui/checkbox.tsx
@@ -1,0 +1,29 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export interface CheckboxProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  onCheckedChange?: (checked: boolean) => void
+}
+
+const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
+  ({ className, onCheckedChange, onChange, ...props }, ref) => {
+    return (
+      <input
+        type="checkbox"
+        className={cn(
+          "h-4 w-4 rounded border border-input bg-transparent shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        onChange={(e) => {
+          onChange?.(e)
+          onCheckedChange?.(e.target.checked)
+        }}
+        {...props}
+      />
+    )
+  }
+)
+Checkbox.displayName = "Checkbox"
+
+export { Checkbox }

--- a/ui/src/components/ui/input.tsx
+++ b/ui/src/components/ui/input.tsx
@@ -1,0 +1,23 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/ui/src/components/ui/label.tsx
+++ b/ui/src/components/ui/label.tsx
@@ -1,0 +1,19 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+const Label = React.forwardRef<
+  HTMLLabelElement,
+  React.LabelHTMLAttributes<HTMLLabelElement>
+>(({ className, ...props }, ref) => (
+  <label
+    ref={ref}
+    className={cn(
+      "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+      className
+    )}
+    {...props}
+  />
+))
+Label.displayName = "Label"
+
+export { Label }

--- a/ui/src/contexts/AuthContext.tsx
+++ b/ui/src/contexts/AuthContext.tsx
@@ -1,0 +1,140 @@
+import { createContext, useContext, useEffect, useState, useCallback } from 'react'
+import { setUnauthorizedHandler } from '@/lib/api'
+import { setWsUnauthorizedHandler } from '@/lib/ws'
+
+interface AuthContextValue {
+  token: string | null
+  isAuthenticated: boolean
+  login: (token: string, remember: boolean) => Promise<void>
+  logout: () => void
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  token: null,
+  isAuthenticated: false,
+  login: async () => {},
+  logout: () => {},
+})
+
+// Module-level token storage for use outside React tree (e.g. in api.ts)
+let _token: string | null = null
+
+export function getToken(): string | null {
+  return _token
+}
+
+function readStoredToken(): string | null {
+  return localStorage.getItem('agentforge_token') ?? sessionStorage.getItem('agentforge_token')
+}
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [token, setToken] = useState<string | null>(() => {
+    const stored = readStoredToken()
+    _token = stored
+    return stored
+  })
+  const [isAuthenticated, setIsAuthenticated] = useState(false)
+  const [checking, setChecking] = useState(true)
+
+  const logout = useCallback(() => {
+    _token = null
+    setToken(null)
+    setIsAuthenticated(false)
+    localStorage.removeItem('agentforge_token')
+    sessionStorage.removeItem('agentforge_token')
+    window.location.href = '/login'
+  }, [])
+
+  // Register the 401 handler so api.ts can call logout
+  useEffect(() => {
+    setUnauthorizedHandler(logout)
+    setWsUnauthorizedHandler(logout)
+  }, [logout])
+
+  // On mount: check if auth is even required (auth_enabled bypass),
+  // or restore token from storage.
+  useEffect(() => {
+    async function checkAuth() {
+      try {
+        const res = await fetch('/api/status')
+        if (res.ok) {
+          const data = await res.json() as { auth_enabled?: boolean }
+          if (data.auth_enabled === false || !Object.prototype.hasOwnProperty.call(data, 'auth_enabled')) {
+            // Auth disabled or status returned 200 without a token — bypass login
+            // Keep any stored token in _token (or leave null); no auth header needed
+            _token = token
+            setIsAuthenticated(true)
+            setChecking(false)
+            return
+          }
+        }
+      } catch {
+        // Network error — fall through to token-based check
+      }
+
+      // Auth is enabled; check stored token
+      if (token) {
+        try {
+          const res = await fetch('/api/status', {
+            headers: { Authorization: `Bearer ${token}` },
+          })
+          if (res.ok) {
+            _token = token
+            setIsAuthenticated(true)
+          } else {
+            // Stored token is no longer valid
+            _token = null
+            setToken(null)
+            setIsAuthenticated(false)
+            localStorage.removeItem('agentforge_token')
+            sessionStorage.removeItem('agentforge_token')
+          }
+        } catch {
+          // Network error — keep token, assume authenticated for now
+          _token = token
+          setIsAuthenticated(true)
+        }
+      }
+      setChecking(false)
+    }
+
+    void checkAuth()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const login = useCallback(async (newToken: string, remember: boolean) => {
+    const res = await fetch('/api/status', {
+      headers: newToken ? { Authorization: `Bearer ${newToken}` } : {},
+    })
+    if (!res.ok) {
+      throw new Error('Invalid token')
+    }
+    _token = newToken
+    setToken(newToken)
+    setIsAuthenticated(true)
+    if (remember) {
+      localStorage.setItem('agentforge_token', newToken)
+    } else {
+      sessionStorage.setItem('agentforge_token', newToken)
+    }
+  }, [])
+
+  // While we're checking auth state, render a minimal spinner (avoids flash of login page)
+  if (checking) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background">
+        <div className="h-8 w-8 rounded-full border-2 border-muted border-t-foreground animate-spin" />
+      </div>
+    )
+  }
+
+  return (
+    <AuthContext.Provider value={{ token, isAuthenticated, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  return useContext(AuthContext)
+}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1,10 +1,34 @@
+import { getToken } from '@/contexts/AuthContext'
+
 const BASE = '/api'
 
+// Module-level callback invoked when a 401 response is received
+let onUnauthorized: (() => void) | null = null
+
+export function setUnauthorizedHandler(fn: () => void) {
+  onUnauthorized = fn
+}
+
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
+  const token = getToken()
+  const authHeaders: Record<string, string> = token
+    ? { Authorization: `Bearer ${token}` }
+    : {}
+
   const res = await fetch(`${BASE}${path}`, {
-    headers: { 'Content-Type': 'application/json' },
     ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeaders,
+      ...(options?.headers as Record<string, string> | undefined),
+    },
   })
+
+  if (res.status === 401) {
+    onUnauthorized?.()
+    throw new Error('Unauthorized')
+  }
+
   if (!res.ok) {
     const err = await res.json().catch(() => ({ error: res.statusText }))
     throw new Error((err as { error?: string }).error ?? res.statusText)

--- a/ui/src/lib/ws.ts
+++ b/ui/src/lib/ws.ts
@@ -1,3 +1,5 @@
+import { getToken } from '@/contexts/AuthContext'
+
 export type WsMessage = {
   event: string
   data: unknown
@@ -6,7 +8,12 @@ export type WsMessage = {
 
 export type WsListener = (msg: WsMessage) => void
 
-const WS_URL = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws`
+// Module-level callback invoked on 4401 close code (unauthorized)
+let onUnauthorized: (() => void) | null = null
+
+export function setWsUnauthorizedHandler(fn: () => void) {
+  onUnauthorized = fn
+}
 
 class WebSocketManager {
   private ws: WebSocket | null = null
@@ -17,12 +24,22 @@ class WebSocketManager {
 
   get status() { return this._status }
 
+  private _buildUrl(): string {
+    const base = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws`
+    const token = getToken()
+    return token ? `${base}?token=${encodeURIComponent(token)}` : base
+  }
+
   connect() {
     if (this.ws?.readyState === WebSocket.OPEN) return
     this._setStatus('connecting')
-    this.ws = new WebSocket(WS_URL)
+    this.ws = new WebSocket(this._buildUrl())
     this.ws.onopen = () => this._setStatus('connected')
-    this.ws.onclose = () => {
+    this.ws.onclose = (evt) => {
+      if (evt.code === 4401) {
+        onUnauthorized?.()
+        return
+      }
       this._setStatus('disconnected')
       this.reconnectTimer = setTimeout(() => this.connect(), 3000)
     }

--- a/ui/src/views/LoginView.tsx
+++ b/ui/src/views/LoginView.tsx
@@ -1,0 +1,93 @@
+import { useState, useEffect, FormEvent } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useAuth } from '@/contexts/AuthContext'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Checkbox } from '@/components/ui/checkbox'
+
+export default function LoginView() {
+  const { isAuthenticated, login } = useAuth()
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+
+  const [tokenValue, setTokenValue] = useState('')
+  const [remember, setRemember] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const rawRedirect = searchParams.get('redirect') ?? '/dashboard'
+  // Guard against open redirect: only allow same-origin relative paths
+  const redirect = rawRedirect.startsWith('/') && !rawRedirect.startsWith('//')
+    ? rawRedirect
+    : '/dashboard'
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      navigate(redirect, { replace: true })
+    }
+  }, [isAuthenticated, navigate, redirect])
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+    try {
+      await login(tokenValue, remember)
+      navigate(redirect, { replace: true })
+    } catch {
+      setError('Invalid token — check your agentforge.yml')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background p-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader className="space-y-1">
+          <CardTitle className="text-2xl">AgentForge</CardTitle>
+          <CardDescription>Enter your API secret to continue</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="token">API Secret</Label>
+              <Input
+                id="token"
+                type="password"
+                placeholder="••••••••"
+                value={tokenValue}
+                onChange={(e) => setTokenValue(e.target.value)}
+                disabled={loading}
+                autoFocus
+                autoComplete="current-password"
+              />
+            </div>
+
+            {error && (
+              <p className="text-sm text-destructive">{error}</p>
+            )}
+
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="remember"
+                checked={remember}
+                onCheckedChange={setRemember}
+                disabled={loading}
+              />
+              <Label htmlFor="remember" className="font-normal cursor-pointer">
+                Remember me
+              </Label>
+            </div>
+
+            <Button type="submit" className="w-full" disabled={loading || !tokenValue}>
+              {loading ? 'Verifying…' : 'Sign in'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds `tests/providers/interface.test.js` with 23 tests for `src/providers/interface.js`
- Tests `BaseProvider`: constructor fields, all three abstract methods throw "not implemented", error messages include provider ID
- Tests `OllamaProvider` against a real HTTP stub: constructor defaults, `execute()` response normalisation, HTTP error handling, missing token counts default to 0, `listModels()`, `healthCheck()` (reachable / unreachable / error status)
- Tests `ProviderRegistry`: register/get, execute delegation, unknown-provider error, `healthCheckAll()`, provider overwrite

## Test plan
- [ ] `node --test tests/providers/interface.test.js` — 23 tests pass