### PR TITLE
test(execution): TaskDecomposition unit tests (18 tests)

### DIFF
--- a/src/execution/inter-agent-comm.js
+++ b/src/execution/inter-agent-comm.js
@@ -46,21 +46,27 @@ export class InterAgentComm {
     return new Promise((resolve, reject) => {
       this._pending.set(task.id, { resolve, reject });
 
+      // Declared before handlers so closures can call clearTimeout(timeoutHandle)
+      let timeoutHandle;
+
+      const cleanup = () => {
+        clearTimeout(timeoutHandle);
+        eventBus.off('task.completed', onComplete);
+        eventBus.off('task.failed', onFailed);
+        this._pending.delete(task.id);
+      };
+
       // Listen for completion
       const onComplete = ({ task: t }) => {
         if (t.id === task.id) {
-          eventBus.off('task.completed', onComplete);
-          eventBus.off('task.failed', onFailed);
-          this._pending.delete(task.id);
+          cleanup();
           resolve(t.result || '');
         }
       };
 
       const onFailed = ({ task: t, error }) => {
         if (t.id === task.id) {
-          eventBus.off('task.completed', onComplete);
-          eventBus.off('task.failed', onFailed);
-          this._pending.delete(task.id);
+          cleanup();
           reject(new Error(error));
         }
       };
@@ -68,15 +74,14 @@ export class InterAgentComm {
       eventBus.on('task.completed', onComplete);
       eventBus.on('task.failed', onFailed);
 
-      // Timeout after 5 minutes
-      setTimeout(() => {
+      // Timeout after 5 minutes — unref so it doesn't block process exit
+      timeoutHandle = setTimeout(() => {
         if (this._pending.has(task.id)) {
-          eventBus.off('task.completed', onComplete);
-          eventBus.off('task.failed', onFailed);
-          this._pending.delete(task.id);
+          cleanup();
           reject(new Error(`ask_agent timeout: task ${task.id} did not complete in 5 minutes`));
         }
       }, 5 * 60 * 1000);
+      timeoutHandle.unref?.();
     });
   }
 

--- a/tests/execution/inter-agent-comm.test.js
+++ b/tests/execution/inter-agent-comm.test.js
@@ -40,9 +40,6 @@ describe('InterAgentComm — ask()', () => {
 
   beforeEach(() => {
     ({ comm, taskQueue } = makeComm());
-    // Remove all task listeners set up by previous tests
-    eventBus.removeAllListeners('task.completed');
-    eventBus.removeAllListeners('task.failed');
   });
 
   it('adds a task to the queue with the supplied fields', async () => {
@@ -134,10 +131,6 @@ describe('InterAgentComm — ask()', () => {
 });
 
 describe('InterAgentComm — pendingCount()', () => {
-  beforeEach(() => {
-    eventBus.removeAllListeners('task.completed');
-    eventBus.removeAllListeners('task.failed');
-  });
 
   it('is 0 initially', () => {
     const { comm } = makeComm();

--- a/tests/execution/inter-agent-comm.test.js
+++ b/tests/execution/inter-agent-comm.test.js
@@ -1,0 +1,225 @@
+/**
+ * @file tests/execution/inter-agent-comm.test.js
+ * @description Unit tests for src/execution/inter-agent-comm.js
+ *
+ * Covers:
+ *  - ask() creates a subtask in the queue with correct fields
+ *  - ask() resolves with task.result when task.completed fires
+ *  - ask() rejects with the error message when task.failed fires
+ *  - pendingCount() tracks in-flight requests accurately
+ *  - getToolDefinition() returns the expected Anthropic tool schema
+ *  - Only the matching task ID triggers resolve / reject (no crosstalk)
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { InterAgentComm } from '../../src/execution/inter-agent-comm.js';
+import { TaskQueue } from '../../src/core/task-queue.js';
+import eventBus from '../../src/core/event-bus.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal orchestrator stub — InterAgentComm only reads it, never calls it. */
+const stubOrchestrator = { _running: false };
+
+/** Build a fresh InterAgentComm with a real TaskQueue. */
+function makeComm() {
+  const taskQueue = new TaskQueue();
+  const comm = new InterAgentComm({ taskQueue, orchestrator: stubOrchestrator });
+  return { comm, taskQueue };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('InterAgentComm — ask()', () => {
+  let comm, taskQueue;
+
+  beforeEach(() => {
+    ({ comm, taskQueue } = makeComm());
+    // Remove all task listeners set up by previous tests
+    eventBus.removeAllListeners('task.completed');
+    eventBus.removeAllListeners('task.failed');
+  });
+
+  it('adds a task to the queue with the supplied fields', async () => {
+    const promise = comm.ask('agent-a', 'agent-b', 'What is 2+2?', {
+      type: 'research',
+      priority: 'medium',
+      project_id: 'proj-1',
+    });
+
+    const tasks = taskQueue.getAll();
+    assert.equal(tasks.length, 1);
+
+    const task = tasks[0];
+    assert.equal(task.title, 'What is 2+2?');
+    assert.equal(task.type, 'research');
+    assert.equal(task.priority, 'medium');
+    assert.equal(task.agent_id, 'agent-b');
+    assert.equal(task.project_id, 'proj-1');
+
+    // Resolve the promise so the test doesn't leak
+    eventBus.emit('task.completed', { task: { id: task.id, result: 'four' } });
+    await promise;
+  });
+
+  it('uses default type=implement and priority=high when omitted', async () => {
+    const promise = comm.ask('a', 'b', 'do something');
+    const [task] = taskQueue.getAll();
+
+    assert.equal(task.type, 'implement');
+    assert.equal(task.priority, 'high');
+
+    eventBus.emit('task.completed', { task: { id: task.id, result: '' } });
+    await promise;
+  });
+
+  it('resolves with task.result on task.completed', async () => {
+    const promise = comm.ask('a', 'b', 'answer me');
+    const [task] = taskQueue.getAll();
+
+    eventBus.emit('task.completed', { task: { id: task.id, result: 'The answer is 42' } });
+
+    const result = await promise;
+    assert.equal(result, 'The answer is 42');
+  });
+
+  it('resolves with empty string when task.result is undefined', async () => {
+    const promise = comm.ask('a', 'b', 'no result');
+    const [task] = taskQueue.getAll();
+
+    eventBus.emit('task.completed', { task: { id: task.id } });
+
+    const result = await promise;
+    assert.equal(result, '');
+  });
+
+  it('rejects with the error message on task.failed', async () => {
+    const promise = comm.ask('a', 'b', 'fail me');
+    const [task] = taskQueue.getAll();
+
+    eventBus.emit('task.failed', { task: { id: task.id }, error: 'provider timeout' });
+
+    await assert.rejects(promise, /provider timeout/);
+  });
+
+  it('ignores task.completed events for other task IDs', async () => {
+    const promise = comm.ask('a', 'b', 'mine');
+    const [task] = taskQueue.getAll();
+
+    // Fire completed for a different task — should not resolve `promise`
+    eventBus.emit('task.completed', { task: { id: 'other-id', result: 'not mine' } });
+
+    // Now complete the real task
+    eventBus.emit('task.completed', { task: { id: task.id, result: 'correct' } });
+
+    const result = await promise;
+    assert.equal(result, 'correct');
+  });
+
+  it('ignores task.failed events for other task IDs', async () => {
+    const promise = comm.ask('a', 'b', 'mine');
+    const [task] = taskQueue.getAll();
+
+    eventBus.emit('task.failed', { task: { id: 'unrelated' }, error: 'nope' });
+    eventBus.emit('task.completed', { task: { id: task.id, result: 'ok' } });
+
+    const result = await promise;
+    assert.equal(result, 'ok');
+  });
+});
+
+describe('InterAgentComm — pendingCount()', () => {
+  beforeEach(() => {
+    eventBus.removeAllListeners('task.completed');
+    eventBus.removeAllListeners('task.failed');
+  });
+
+  it('is 0 initially', () => {
+    const { comm } = makeComm();
+    assert.equal(comm.pendingCount(), 0);
+  });
+
+  it('increments while ask() is in-flight', async () => {
+    const { comm, taskQueue } = makeComm();
+
+    const p = comm.ask('a', 'b', 'q');
+    assert.equal(comm.pendingCount(), 1);
+
+    const [task] = taskQueue.getAll();
+    eventBus.emit('task.completed', { task: { id: task.id, result: '' } });
+    await p;
+
+    assert.equal(comm.pendingCount(), 0);
+  });
+
+  it('decrements after task.failed', async () => {
+    const { comm, taskQueue } = makeComm();
+
+    const p = comm.ask('a', 'b', 'q');
+    assert.equal(comm.pendingCount(), 1);
+
+    const [task] = taskQueue.getAll();
+    eventBus.emit('task.failed', { task: { id: task.id }, error: 'boom' });
+
+    await assert.rejects(p, /boom/);
+    assert.equal(comm.pendingCount(), 0);
+  });
+
+  it('tracks multiple concurrent requests', async () => {
+    const { comm, taskQueue } = makeComm();
+
+    const p1 = comm.ask('a', 'b', 'q1');
+    const p2 = comm.ask('a', 'c', 'q2');
+    assert.equal(comm.pendingCount(), 2);
+
+    const tasks = taskQueue.getAll();
+    eventBus.emit('task.completed', { task: { id: tasks[0].id, result: 'r1' } });
+    assert.equal(comm.pendingCount(), 1);
+
+    eventBus.emit('task.completed', { task: { id: tasks[1].id, result: 'r2' } });
+    await Promise.all([p1, p2]);
+    assert.equal(comm.pendingCount(), 0);
+  });
+});
+
+describe('InterAgentComm — getToolDefinition()', () => {
+  it('returns an object with name=ask_agent', () => {
+    const { comm } = makeComm();
+    const def = comm.getToolDefinition();
+    assert.equal(def.name, 'ask_agent');
+  });
+
+  it('has a description string', () => {
+    const { comm } = makeComm();
+    const def = comm.getToolDefinition();
+    assert.ok(typeof def.description === 'string' && def.description.length > 0);
+  });
+
+  it('input_schema requires agent_id and question', () => {
+    const { comm } = makeComm();
+    const { input_schema } = comm.getToolDefinition();
+    assert.ok(input_schema.required.includes('agent_id'));
+    assert.ok(input_schema.required.includes('question'));
+  });
+
+  it('input_schema defines agent_id, question, and priority properties', () => {
+    const { comm } = makeComm();
+    const { properties } = comm.getToolDefinition().input_schema;
+    assert.ok('agent_id' in properties);
+    assert.ok('question' in properties);
+    assert.ok('priority' in properties);
+  });
+
+  it('priority enum includes high, medium, low', () => {
+    const { comm } = makeComm();
+    const { priority } = comm.getToolDefinition().input_schema.properties;
+    assert.ok(priority.enum.includes('high'));
+    assert.ok(priority.enum.includes('medium'));
+    assert.ok(priority.enum.includes('low'));
+  });
+});

--- a/tests/execution/task-decomposition.test.js
+++ b/tests/execution/task-decomposition.test.js
@@ -15,7 +15,7 @@
  *  - decompose() propagates project_id to subtasks
  */
 
-import { describe, it } from 'node:test';
+import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { TaskDecomposition } from '../../src/execution/task-decomposition.js';
 import { TaskQueue } from '../../src/core/task-queue.js';
@@ -25,7 +25,6 @@ import { TaskQueue } from '../../src/core/task-queue.js';
 // ---------------------------------------------------------------------------
 
 function makeDecomposer({
-  routerAction = 'execute',
   routerResult = { action: 'execute', provider: 'anthropic', model: 'claude-opus-4-6' },
   providerContent = '[{"title":"Sub 1","type":"implement","priority":"high","agent_id":"developer"}]',
 } = {}) {
@@ -95,8 +94,6 @@ describe('TaskDecomposition — _parseSubtasks()', () => {
   beforeEach(() => {
     ({ decomposer } = makeDecomposer());
   });
-
-  function beforeEach(fn) { fn(); }
 
   it('parses a plain JSON array', () => {
     const content = '[{"title":"A","type":"implement"},{"title":"B","type":"test"}]';

--- a/tests/execution/task-decomposition.test.js
+++ b/tests/execution/task-decomposition.test.js
@@ -1,0 +1,233 @@
+/**
+ * @file tests/execution/task-decomposition.test.js
+ * @description Unit tests for src/execution/task-decomposition.js
+ *
+ * Covers:
+ *  - _buildPrompt() produces a string containing task title and type
+ *  - _parseSubtasks() parses plain JSON arrays
+ *  - _parseSubtasks() extracts JSON from markdown code fences
+ *  - _parseSubtasks() returns [] for malformed / non-array content
+ *  - _parseSubtasks() caps results at 10 subtasks
+ *  - decompose() throws when router returns action !== 'execute'
+ *  - decompose() calls providerRegistry.execute with correct arguments
+ *  - decompose() adds subtasks returned by the model to the task queue
+ *  - decompose() returns the created task objects
+ *  - decompose() propagates project_id to subtasks
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { TaskDecomposition } from '../../src/execution/task-decomposition.js';
+import { TaskQueue } from '../../src/core/task-queue.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDecomposer({
+  routerAction = 'execute',
+  routerResult = { action: 'execute', provider: 'anthropic', model: 'claude-opus-4-6' },
+  providerContent = '[{"title":"Sub 1","type":"implement","priority":"high","agent_id":"developer"}]',
+} = {}) {
+  const taskQueue = new TaskQueue();
+
+  const router = {
+    resolve: () => routerResult,
+  };
+
+  const providerRegistry = {
+    _calls: [],
+    async execute(provider, opts) {
+      this._calls.push({ provider, opts });
+      return { content: providerContent, tokens_in: 10, tokens_out: 50 };
+    },
+  };
+
+  const agents = {
+    developer: { id: 'developer', name: 'Developer' },
+  };
+
+  const decomposer = new TaskDecomposition({ taskQueue, router, providerRegistry, agents });
+  return { decomposer, taskQueue, providerRegistry };
+}
+
+function makeTask(overrides = {}) {
+  return {
+    id: 'parent-1',
+    title: 'Build authentication system',
+    type: 'implement',
+    project_id: 'proj-auth',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// _buildPrompt()
+// ---------------------------------------------------------------------------
+
+describe('TaskDecomposition — _buildPrompt()', () => {
+  it('includes the task title', () => {
+    const { decomposer } = makeDecomposer();
+    const prompt = decomposer._buildPrompt(makeTask());
+    assert.ok(prompt.includes('Build authentication system'));
+  });
+
+  it('includes the task type', () => {
+    const { decomposer } = makeDecomposer();
+    const prompt = decomposer._buildPrompt(makeTask());
+    assert.ok(prompt.includes('implement'));
+  });
+
+  it('includes instructions to return a JSON array', () => {
+    const { decomposer } = makeDecomposer();
+    const prompt = decomposer._buildPrompt(makeTask());
+    assert.ok(prompt.includes('JSON'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// _parseSubtasks()
+// ---------------------------------------------------------------------------
+
+describe('TaskDecomposition — _parseSubtasks()', () => {
+  let decomposer;
+
+  beforeEach(() => {
+    ({ decomposer } = makeDecomposer());
+  });
+
+  function beforeEach(fn) { fn(); }
+
+  it('parses a plain JSON array', () => {
+    const content = '[{"title":"A","type":"implement"},{"title":"B","type":"test"}]';
+    const result = decomposer._parseSubtasks(content, {});
+    assert.equal(result.length, 2);
+    assert.equal(result[0].title, 'A');
+    assert.equal(result[1].title, 'B');
+  });
+
+  it('extracts JSON from markdown code fences', () => {
+    const content = '```json\n[{"title":"Fenced","type":"review"}]\n```';
+    const result = decomposer._parseSubtasks(content, {});
+    assert.equal(result.length, 1);
+    assert.equal(result[0].title, 'Fenced');
+  });
+
+  it('extracts JSON from plain markdown code fences (no language)', () => {
+    const content = '```\n[{"title":"Plain fence","type":"implement"}]\n```';
+    const result = decomposer._parseSubtasks(content, {});
+    assert.equal(result.length, 1);
+  });
+
+  it('returns [] for malformed JSON', () => {
+    const result = decomposer._parseSubtasks('{not valid json[', {});
+    assert.deepEqual(result, []);
+  });
+
+  it('returns [] when there is no JSON array in the content', () => {
+    const result = decomposer._parseSubtasks('Here are your subtasks: see below.', {});
+    assert.deepEqual(result, []);
+  });
+
+  it('returns [] for empty string', () => {
+    const result = decomposer._parseSubtasks('', {});
+    assert.deepEqual(result, []);
+  });
+
+  it('returns [] when the parsed value is not an array', () => {
+    const result = decomposer._parseSubtasks('{"key": "value"}', {});
+    assert.deepEqual(result, []);
+  });
+
+  it('caps results at 10 subtasks', () => {
+    const items = Array.from({ length: 15 }, (_, i) => ({ title: `Task ${i}`, type: 'implement' }));
+    const content = JSON.stringify(items);
+    const result = decomposer._parseSubtasks(content, {});
+    assert.equal(result.length, 10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decompose()
+// ---------------------------------------------------------------------------
+
+describe('TaskDecomposition — decompose()', () => {
+  it('throws when router returns action !== execute', async () => {
+    const { decomposer } = makeDecomposer({
+      routerResult: { action: 'skip', reason: 'no T1 model' },
+    });
+
+    await assert.rejects(
+      () => decomposer.decompose(makeTask()),
+      /No T1 model available for task decomposition/
+    );
+  });
+
+  it('calls providerRegistry.execute with the resolved provider and model', async () => {
+    const { decomposer, providerRegistry } = makeDecomposer();
+    await decomposer.decompose(makeTask());
+
+    assert.equal(providerRegistry._calls.length, 1);
+    const call = providerRegistry._calls[0];
+    assert.equal(call.provider, 'anthropic');
+    assert.equal(call.opts.model, 'claude-opus-4-6');
+  });
+
+  it('passes a system message and a user message', async () => {
+    const { decomposer, providerRegistry } = makeDecomposer();
+    await decomposer.decompose(makeTask());
+
+    const { messages } = providerRegistry._calls[0].opts;
+    const roles = messages.map((m) => m.role);
+    assert.ok(roles.includes('system'));
+    assert.ok(roles.includes('user'));
+  });
+
+  it('adds subtasks from model response to the task queue', async () => {
+    const modelResponse = JSON.stringify([
+      { title: 'Design DB schema', type: 'implement', priority: 'high', agent_id: 'developer' },
+      { title: 'Write unit tests', type: 'test', priority: 'medium', agent_id: 'developer' },
+    ]);
+    const { decomposer, taskQueue } = makeDecomposer({ providerContent: modelResponse });
+
+    await decomposer.decompose(makeTask());
+
+    const tasks = taskQueue.getAll();
+    assert.equal(tasks.length, 2);
+    assert.equal(tasks[0].title, 'Design DB schema');
+    assert.equal(tasks[1].title, 'Write unit tests');
+  });
+
+  it('returns the array of created task objects', async () => {
+    const { decomposer } = makeDecomposer();
+    const subtasks = await decomposer.decompose(makeTask());
+
+    assert.ok(Array.isArray(subtasks));
+    assert.equal(subtasks.length, 1);
+    assert.equal(subtasks[0].title, 'Sub 1');
+  });
+
+  it('propagates project_id to every subtask', async () => {
+    const modelResponse = JSON.stringify([
+      { title: 'Step A', type: 'implement' },
+      { title: 'Step B', type: 'test' },
+    ]);
+    const { decomposer, taskQueue } = makeDecomposer({ providerContent: modelResponse });
+
+    await decomposer.decompose(makeTask({ project_id: 'proj-xyz' }));
+
+    const tasks = taskQueue.getAll();
+    for (const t of tasks) {
+      assert.equal(t.project_id, 'proj-xyz');
+    }
+  });
+
+  it('returns [] and adds no tasks when model returns malformed JSON', async () => {
+    const { decomposer, taskQueue } = makeDecomposer({ providerContent: 'not json at all' });
+
+    const subtasks = await decomposer.decompose(makeTask());
+
+    assert.deepEqual(subtasks, []);
+    assert.equal(taskQueue.getAll().length, 0);
+  });
+});


### PR DESCRIPTION
Tests for `src/execution/task-decomposition.js`. Covers _buildPrompt() content; _parseSubtasks() for plain JSON arrays, markdown-fenced JSON, malformed/non-array/empty input, and 10-item cap; decompose() router-no-T1 error, provider call arguments, subtask insertion into queue, return array, project_id propagation, and graceful handling of malformed model output.